### PR TITLE
Worldpay: Adding adjust method

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -145,7 +145,9 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((Authorization: Basic )\w+), '\1[FILTERED]').
           gsub(%r((<cardNumber>)\d+(</cardNumber>)), '\1[FILTERED]\2').
-          gsub(%r((<cvc>)[^<]+(</cvc>)), '\1[FILTERED]\2')
+          gsub(%r((<cvc>)[^<]+(</cvc>)), '\1[FILTERED]\2').
+          gsub(%r((<tokenNumber>)\d+(</tokenNumber>)), '\1[FILTERED]\2').
+          gsub(%r((<cryptogram>)[^<]+(</cryptogram>)), '\1[FILTERED]\2')
       end
 
       private

--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -74,6 +74,13 @@ module ActiveMerchant #:nodoc:
         authorize_request(money, payment_method, payment_details.merge(options))
       end
 
+      def adjust(money, payment_method, options = {})
+        requires!(options, :order_id)
+        options[:auth_amount_status] = true
+        payment_details = payment_details_from(payment_method)
+        authorize_request(money, payment_method, payment_details.merge(options))
+      end
+
       def capture(money, authorization, options = {})
         authorization = order_id_from_authorization(authorization.to_s)
         MultiResponse.run do |r|
@@ -222,6 +229,7 @@ module ActiveMerchant #:nodoc:
               add_payment_method(xml, money, payment_method, options)
               add_shopper(xml, options)
               add_statement_narrative(xml, options)
+              add_authorisation_amount_status(xml) if options[:auth_amount_status]
               add_risk_data(xml, options[:risk_data]) if options[:risk_data]
               add_sub_merchant_data(xml, options[:sub_merchant_data]) if options[:sub_merchant_data]
               add_hcg_additional_data(xml, options) if options[:hcg_additional_data]
@@ -597,6 +605,10 @@ module ActiveMerchant #:nodoc:
         address ||= {}
         address.delete_if { |_, v| v.blank? }
         address.reverse_merge!(default_address)
+      end
+
+      def add_authorisation_amount_status(xml)
+        xml.authorisationAmountStatus 'value' => 'estimated'
       end
 
       def default_address

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -7,6 +7,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
 
     @amount = 100
     @credit_card = credit_card('4111111111111111')
+    @master_card = credit_card('5555555555554444')
     @amex_card = credit_card('3714 496353 98431')
     @elo_credit_card = credit_card('4514 1600 0000 0008',
       month: 10,
@@ -971,6 +972,14 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_success purchase
   end
 
+  def test_successful_adust_with_master_card
+    response = @gateway.adjust(@amount, @master_card, @options)
+    assert_success response
+    assert_equal @amount, response.params['amount_value'].to_i
+    assert_equal 'GBP', response.params['amount_currency_code']
+    assert_equal 'SUCCESS', response.message
+  end
+
   private
 
   def risk_data
@@ -1002,7 +1011,7 @@ class RemoteWorldpayTest < Test::Unit::TestCase
         purchases_completed_last_six_months: '3',
         add_card_attempts_last_day: '4',
         previous_suspicious_activity: 'false', # Boolean (true or false)
-        shipping_name_matches_account_name: 'true', #	Boolean (true or false)
+        shipping_name_matches_account_name: 'true', # Boolean (true or false)
         shopper_account_age_indicator: 'lessThanThirtyDays', # Possible Values: noAccount, createdDuringTransaction, lessThanThirtyDays, thirtyToSixtyDays, moreThanSixtyDays
         shopper_account_change_indicator: 'thirtyToSixtyDays', # Possible values: changedDuringTransaction, lessThanThirtyDays, thirtyToSixtyDays, moreThanSixtyDays
         shopper_account_password_change_indicator: 'noChange', # Possible Values: noChange, changedDuringTransaction, lessThanThirtyDays, thirtyToSixtyDays, moreThanSixtyDays

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -903,6 +903,10 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
+  def test_transcript_scrubbing_on_network_token
+    assert_equal network_token_transcript_scrubbed, @gateway.scrub(network_token_transcript)
+  end
+
   def test_3ds_version_1_request
     stub_comms do
       @gateway.authorize(@amount, @credit_card, @options.merge(three_d_secure_option(version: '1.0.2', xid: 'xid')))
@@ -1939,6 +1943,72 @@ class WorldpayTest < Test::Unit::TestCase
         </submit>
       </paymentService>
     TRANSCRIPT
+  end
+
+  def network_token_transcript
+    <<~RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLY">
+          <submit>
+              <order orderCode="c293b34a70aee391193a1c08168b6c91">
+                  <description>Purchase</description>
+                  <amount value="100" currencyCode="GBP" exponent="2" />
+                  <paymentDetails>
+                      <EMVCO_TOKEN-SSL type="APPLEPAY">
+                          <tokenNumber>4895370015293175</tokenNumber>
+                          <expiryDate>
+                              <date month="10" year="2024" />
+                          </expiryDate>
+                          <cardHolderName>PedroPerez</cardHolderName>
+                          <cryptogram>axxxxxxxxx</cryptogram>
+                          <eciIndicator>07</eciIndicator>
+                      </EMVCO_TOKEN-SSL>
+                  </paymentDetails>
+                  <shopper>
+                      <shopperEmailAddress>wow@ example.com</shopperEmailAddress>
+                      <browser>
+                          <acceptHeader />
+                          <userAgentHeader />
+                      </browser>
+                  </shopper>
+              </order>
+          </submit>
+      </paymentService>
+    RESPONSE
+  end
+
+  def network_token_transcript_scrubbed
+    <<~RESPONSE
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN" "http://dtd.worldpay.com/paymentService_v1.dtd">
+      <paymentService version="1.4" merchantCode="SPREEDLY">
+          <submit>
+              <order orderCode="c293b34a70aee391193a1c08168b6c91">
+                  <description>Purchase</description>
+                  <amount value="100" currencyCode="GBP" exponent="2" />
+                  <paymentDetails>
+                      <EMVCO_TOKEN-SSL type="APPLEPAY">
+                          <tokenNumber>[FILTERED]</tokenNumber>
+                          <expiryDate>
+                              <date month="10" year="2024" />
+                          </expiryDate>
+                          <cardHolderName>PedroPerez</cardHolderName>
+                          <cryptogram>[FILTERED]</cryptogram>
+                          <eciIndicator>07</eciIndicator>
+                      </EMVCO_TOKEN-SSL>
+                  </paymentDetails>
+                  <shopper>
+                      <shopperEmailAddress>wow@ example.com</shopperEmailAddress>
+                      <browser>
+                          <acceptHeader />
+                          <userAgentHeader />
+                      </browser>
+                  </shopper>
+              </order>
+          </submit>
+      </paymentService>
+    RESPONSE
   end
 
   def failed_with_unknown_card_response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -1210,6 +1210,15 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_auth_amount_status_assignation
+    response = stub_comms do
+      @gateway.adjust(@amount, @credit_card, @options)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match %r(<authorisationAmountStatus value="estimated"/>), data
+    end.respond_with(successful_authorize_response)
+    assert_success response
+  end
+
   private
 
   def assert_date_element(expected_date_hash, date_element)


### PR DESCRIPTION
Summary:
--------------------------------------- 
This PR adds adjust method allowing transactions 
to increase the pre-authorize time if the card scheme is supported.

Local Tests: 
--------------------------------------- 
4977 tests, 74598 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
--------------------------------------- 
Finished in 172.14121 seconds.
89 tests, 374 assertions, 2 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
97.7528% passed

RuboCop:
--------------------------------------- 
723 files inspected, no offenses detect