### PR TITLE
Stripe: API version updated

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe.rb
+++ b/lib/active_merchant/billing/gateways/stripe.rb
@@ -23,7 +23,7 @@ module ActiveMerchant #:nodoc:
         'unchecked' => 'P'
       }
 
-      DEFAULT_API_VERSION = '2015-04-07'
+      DEFAULT_API_VERSION = '2020-08-27'
 
       self.supported_countries = %w(AE AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IN IT JP LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US)
       self.default_currency = 'USD'
@@ -222,10 +222,12 @@ module ActiveMerchant #:nodoc:
             r.process { commit(:post, "customers/#{CGI.escape(options[:customer])}/cards", params, options) }
 
             post[:default_card] = r.params['id'] if options[:set_default] && r.success? && !r.params['id'].blank?
+            post[:expand] = [:sources]
 
             r.process { update_customer(options[:customer], post) } if post.count > 0
           end
         else
+          post[:expand] = [:sources]
           commit(:post, 'customers', post.merge(params), options)
         end
       end
@@ -762,7 +764,7 @@ module ActiveMerchant #:nodoc:
             country: 'US',
             currency: 'usd',
             routing_number: bank_account.routing_number,
-            name: bank_account.name,
+            account_holder_name: bank_account.name,
             account_holder_type: account_holder_type
           }
         }

--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -10,7 +10,7 @@ module ActiveMerchant #:nodoc:
       CREATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email save_payment_method]
       CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
       UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email setup_future_usage]
-      DEFAULT_API_VERSION = '2019-05-16'
+      DEFAULT_API_VERSION = '2020-08-27'
 
       def create_intent(money, payment_method, options = {})
         post = {}
@@ -192,6 +192,7 @@ module ActiveMerchant #:nodoc:
             post[:description] = options[:description] if options[:description]
             post[:email] = options[:email] if options[:email]
             options = format_idempotency_key(options, 'customer')
+            post[:expand] = [:sources]
             customer = commit(:post, 'customers', post, options)
             customer_id = customer.params['id']
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
+          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials


### PR DESCRIPTION
### Summary:

This PR changes the API version to the latest version available (2020-08-27), also includes the update of the use of method YAML.safe_load to avoid a warning on test helper

### Test Execution:
test/remote/gateways/remote_stripe_test.rb
Finished in 122.237642 seconds.

74 tests, 338 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
98.6486% passed

test/remote/gateways/remote_stripe_payment_intents_test.rb
Finished in 164.5804 seconds.

66 tests, 313 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

RuboCop:
------------------------------
725 files inspected, no offenses detected