### PR TITLE
Remove YAML warning on load_fixtures_method

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -281,7 +281,7 @@ module ActiveMerchant
     def load_fixtures
       [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
         if File.exist?(file_name)
-          yaml_data = YAML.safe_load(File.read(file_name), [], [], true)
+          yaml_data = YAML.safe_load(File.read(file_name), aliases: true)
           credentials.merge!(symbolize_keys(yaml_data))
         end
         credentials


### PR DESCRIPTION
Summary:
------------------------------
This PR updates the safe_load method use on test_helper file avoiding a deprecated use

Test Execution:
------------------------------
Finished in 17.796721 seconds.

5004 tests, 74828 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

281.18 tests/s, 4204.59 assertions/s

Running RuboCop...

725 files inspected, no offenses detected