### PR TITLE
Testing: Adding and configure VCR to be used on remote tests

### DIFF
--- a/activemerchant.gemspec
+++ b/activemerchant.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('test-unit', '~> 3')
   s.add_development_dependency('thor')
+  s.add_development_dependency('vcr')
+  s.add_development_dependency('webmock')
 end

--- a/test/remote/gateways/remote_stripe_test.rb
+++ b/test/remote/gateways/remote_stripe_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class RemoteStripeTest < Test::Unit::TestCase
+  prepend VCRRemote
+
   def setup
     @gateway = StripeGateway.new(fixtures(:stripe))
 

--- a/test/support/vcr_module.rb
+++ b/test/support/vcr_module.rb
@@ -1,0 +1,38 @@
+# Given the remote tests state the VCR gem will be initially disabled and
+# is only going to be available on tests that enables the VCRModule, for
+# that the only needed step is to add VCRModule with as a prepend module.
+
+module VCRRemote
+  def setup
+    class_name = self.name.match(/\((\w*)\)/)[1]
+
+    unless config_already_defined?
+      VCR.configure do |conf|
+        conf.before_record do |interaction|
+          if @gateway.supports_scrubbing?
+            interaction.request.body = @gateway.scrub(interaction.request.body)
+            interaction.response.body = @gateway.scrub(interaction.response.body)
+          end
+        end
+      end
+    end
+
+    VCR.turn_on!
+    VCR.insert_cassette([class_name, method_name].compact.join('/').underscore)
+    super
+  end
+
+  def teardown
+    VCR.eject_cassette
+    VCR.turn_off!
+    super
+  end
+
+  private
+
+  def config_already_defined?
+    VCR.configuration.hooks[:before_record].any? do |hook|
+      hook.hook.source_location.first =~ /vcr_module/
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,8 @@ require 'yaml'
 require 'json'
 require 'active_merchant'
 require 'comm_stub'
+require 'vcr'
+require 'support/vcr_module'
 
 require 'active_support/core_ext/integer/time'
 require 'active_support/core_ext/numeric/time'
@@ -341,3 +343,30 @@ class MockResponse
     @headers[header]
   end
 end
+
+# Given the remote tests state the VCR gem will be initially disabled and
+# is only going to be available on tests that enables the VCRModule, for
+# that the only needed step is to add VCRModule with as a prepend module.
+VCR.configure do |config|
+  config.cassette_library_dir = 'test/vcr_cassettes'
+  config.allow_http_connections_when_no_cassette = true
+  config.hook_into :webmock
+  config.default_cassette_options = {
+    record: :once,
+    update_content_length_header: true, # Enables response body modification and prevent errors/bugs with some libraries
+    allow_unused_http_interactions: false # Behaves like a mock object
+  }
+
+  # filter out any Basic and Bearer headers on request
+  config.filter_sensitive_data('<AUTH_DATA>') do |interaction|
+    (interaction.request.headers['Authorization'] || ['']).first.split(' ').last
+  end
+
+  # extend the indentification of a unique request
+  config.default_cassette_options = {
+    match_requests_on: %i[method host path]
+  }
+end
+
+VCR.turn_off!
+WebMock.allow_net_connect!

--- a/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - c3499f4e-4f8d-4d0b-9d9d-c9dc211db9d7
+      Original-Request:
+      - req_pP3L5hu5ol3Q2h
+      Request-Id:
+      - req_pP3L5hu5ol3Q2h
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dknAWOtgoysog09QuESkQ",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498885,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 53,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkmAWOtgoysogh3Qx7pig",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dknAWOtgoysog09QuESkQ/rcpt_KmC9JbE2UIXDRxREKDns9VpzVbIWhVV",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dknAWOtgoysog09QuESkQ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkmAWOtgoysogh3Qx7pig",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:25 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dknAWOtgoysog09QuESkQ/capture
+    body:
+      encoding: UTF-8
+      string: amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 6c346e5f-b991-4085-a43b-ebc45219e894
+      Original-Request:
+      - req_stQXXcxJQkkmVl
+      Request-Id:
+      - req_stQXXcxJQkkmVl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dknAWOtgoysog09QuESkQ",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dknAWOtgoysog0IW1izZP",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498885,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 53,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkmAWOtgoysogh3Qx7pig",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dknAWOtgoysog09QuESkQ/rcpt_KmC9JbE2UIXDRxREKDns9VpzVbIWhVV",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dknAWOtgoysog09QuESkQ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkmAWOtgoysogh3Qx7pig",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:26 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture_with_destination.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture_with_destination.yml
@@ -1,0 +1,400 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3252'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - b58b81e8-6919-41b4-a25e-b4cb72ff6237
+      Original-Request:
+      - req_Soj7MAF5g3RhlP
+      Request-Id:
+      - req_Soj7MAF5g3RhlP
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dkpAWOtgoysog0eaSlZiq",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": false,
+          "created": 1639498887,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 0,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkpAWOtgoysogM2RKOZbi",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkpAWOtgoysog0eaSlZiq/rcpt_KmC916cSEFQ4yWi3UzkoIrEG7DlVX5C",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dkpAWOtgoysog0eaSlZiq/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkpAWOtgoysogM2RKOZbi",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": {
+            "amount": null,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dkpAWOtgoysog0eaSlZiq"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:28 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dkpAWOtgoysog0eaSlZiq/capture
+    body:
+      encoding: UTF-8
+      string: amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3324'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 90e08d18-b967-4423-99ab-753c5f69d1fc
+      Original-Request:
+      - req_8oVQYhOiLrbZym
+      Request-Id:
+      - req_8oVQYhOiLrbZym
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dkpAWOtgoysog0eaSlZiq",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dkpAWOtgoysog0UsvKlAn",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498887,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 0,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkpAWOtgoysogM2RKOZbi",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkpAWOtgoysog0eaSlZiq/rcpt_KmC916cSEFQ4yWi3UzkoIrEG7DlVX5C",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dkpAWOtgoysog0eaSlZiq/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkpAWOtgoysogM2RKOZbi",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dkpAWOtgoysog0ts8OeXJ",
+          "transfer_data": {
+            "amount": null,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dkpAWOtgoysog0eaSlZiq"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:30 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture_with_destination_and_amount.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_authorization_and_capture_with_destination_and_amount.yml
@@ -1,0 +1,400 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn&destination[amount]=80&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3251'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d318009c-b9f9-45e7-80cb-604fa4e37ec4
+      Original-Request:
+      - req_epJVLjP9NhKEHK
+      Request-Id:
+      - req_epJVLjP9NhKEHK
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dktAWOtgoysog20g0231s",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": false,
+          "created": 1639498891,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 34,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dksAWOtgoysogaXGPdnoC",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dktAWOtgoysog20g0231s/rcpt_KmC99Gjs5zVRY8TcsT1fECGgzFyKJYf",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dktAWOtgoysog20g0231s/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dksAWOtgoysogaXGPdnoC",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": {
+            "amount": 80,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dktAWOtgoysog20g0231s"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:31 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dktAWOtgoysog20g0231s/capture
+    body:
+      encoding: UTF-8
+      string: amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3323'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f1356f02-2a57-4031-8164-ceabc6a8e311
+      Original-Request:
+      - req_PCUq6oOD9LPYBo
+      Request-Id:
+      - req_PCUq6oOD9LPYBo
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dktAWOtgoysog20g0231s",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dktAWOtgoysog236pvGta",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498891,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 34,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dksAWOtgoysogaXGPdnoC",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dktAWOtgoysog20g0231s/rcpt_KmC99Gjs5zVRY8TcsT1fECGgzFyKJYf",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dktAWOtgoysog20g0231s/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dksAWOtgoysogaXGPdnoC",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dktAWOtgoysog2VLyPnH1",
+          "transfer_data": {
+            "amount": 80,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dktAWOtgoysog20g0231s"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:33 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_authorization_and_void.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_authorization_and_void.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 927b59bf-0f16-4a64-870e-9a49ab73ef1d
+      Original-Request:
+      - req_uhy44rFyDodAD9
+      Request-Id:
+      - req_uhy44rFyDodAD9
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dkwAWOtgoysog1ylGS5f6",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498894,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 14,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkwAWOtgoysog0Yfc6kEA",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkwAWOtgoysog1ylGS5f6/rcpt_KmC9qGGrlPdNbFnMplYVBzPCmyL6F6b",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dkwAWOtgoysog1ylGS5f6/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkwAWOtgoysog0Yfc6kEA",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:34 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dkwAWOtgoysog1ylGS5f6/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 3efa8052-5f7a-40dc-a96a-c9c69afc6e22
+      Original-Request:
+      - req_36bvsuvRXMtqLa
+      Request-Id:
+      - req_36bvsuvRXMtqLa
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dkwAWOtgoysog1HHu43vE",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dkwAWOtgoysog1ylGS5f6",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498894,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 14,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dkwAWOtgoysog0Yfc6kEA",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkwAWOtgoysog1ylGS5f6/rcpt_KmC9qGGrlPdNbFnMplYVBzPCmyL6F6b",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dkwAWOtgoysog1HHu43vE",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dkwAWOtgoysog1ylGS5f6",
+                  "created": 1639498895,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dkwAWOtgoysog1ylGS5f6/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dkwAWOtgoysog0Yfc6kEA",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498895,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:36 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_card_present_authorize_and_capture.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_card_present_authorize_and_capture.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[swipe_data]=[FILTERED]&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3117'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 445dcc30-68a5-4bda-ac78-599a29419773
+      Original-Request:
+      - req_7jnmloL5GKAWIU
+      Request-Id:
+      - req_7jnmloL5GKAWIU
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dkyAWOtgoysog3j3q8xdD",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "LONGSON/LONGBOB",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498896,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 6,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkyAWOtgoysogxkQk28QZ",
+          "payment_method_details": {
+            "card": {
+              "brand": "amex",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": null
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 5,
+              "exp_year": 2022,
+              "fingerprint": "DjZpoV89lmOMsJLF",
+              "funding": "credit",
+              "installments": null,
+              "last4": "0005",
+              "mandate": null,
+              "moto": null,
+              "network": "amex",
+              "network_transaction_id": "6810690112111865",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkyAWOtgoysog3j3q8xdD/rcpt_KmC9Y6jVdd2qYTOBicgs5sanEY8VT9m",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dkyAWOtgoysog3j3q8xdD/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkyAWOtgoysogxkQk28QZ",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "American Express",
+            "country": "US",
+            "customer": null,
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 5,
+            "exp_year": 2022,
+            "fingerprint": "DjZpoV89lmOMsJLF",
+            "funding": "credit",
+            "last4": "0005",
+            "metadata": {
+            },
+            "name": "LONGSON/LONGBOB",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:37 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dkyAWOtgoysog3j3q8xdD/capture
+    body:
+      encoding: UTF-8
+      string: amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3144'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ad314dd4-cfb5-4ebb-a746-1845da630add
+      Original-Request:
+      - req_xMjErvspaL9w8v
+      Request-Id:
+      - req_xMjErvspaL9w8v
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dkyAWOtgoysog3j3q8xdD",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dkyAWOtgoysog3tliI5H2",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "LONGSON/LONGBOB",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498896,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 6,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dkyAWOtgoysogxkQk28QZ",
+          "payment_method_details": {
+            "card": {
+              "brand": "amex",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": null
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 5,
+              "exp_year": 2022,
+              "fingerprint": "DjZpoV89lmOMsJLF",
+              "funding": "credit",
+              "installments": null,
+              "last4": "0005",
+              "mandate": null,
+              "moto": null,
+              "network": "amex",
+              "network_transaction_id": "6810690112111865",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dkyAWOtgoysog3j3q8xdD/rcpt_KmC9Y6jVdd2qYTOBicgs5sanEY8VT9m",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dkyAWOtgoysog3j3q8xdD/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dkyAWOtgoysogxkQk28QZ",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "American Express",
+            "country": "US",
+            "customer": null,
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 5,
+            "exp_year": 2022,
+            "fingerprint": "DjZpoV89lmOMsJLF",
+            "funding": "credit",
+            "last4": "0005",
+            "metadata": {
+            },
+            "name": "LONGSON/LONGBOB",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:38 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_card_present_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_card_present_purchase.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[swipe_data]=[FILTERED]&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3144'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 7559e29f-6b2a-4cae-84f0-dbcb10280aee
+      Original-Request:
+      - req_PfhyDRhdlyfABX
+      Request-Id:
+      - req_PfhyDRhdlyfABX
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dl1AWOtgoysog0nPk7ofJ",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dl1AWOtgoysog0zIfIWix",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "LONGSON/LONGBOB",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498899,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 9,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dl1AWOtgoysogoOzJPyQy",
+          "payment_method_details": {
+            "card": {
+              "brand": "amex",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": null
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 5,
+              "exp_year": 2022,
+              "fingerprint": "DjZpoV89lmOMsJLF",
+              "funding": "credit",
+              "installments": null,
+              "last4": "0005",
+              "mandate": null,
+              "moto": null,
+              "network": "amex",
+              "network_transaction_id": "6810690112111865",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dl1AWOtgoysog0nPk7ofJ/rcpt_KmC9e6gL1OTWlEQSDehsdwzDNdGOamo",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dl1AWOtgoysog0nPk7ofJ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dl1AWOtgoysogoOzJPyQy",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "American Express",
+            "country": "US",
+            "customer": null,
+            "cvc_check": null,
+            "dynamic_last4": null,
+            "exp_month": 5,
+            "exp_year": 2022,
+            "fingerprint": "DjZpoV89lmOMsJLF",
+            "funding": "credit",
+            "last4": "0005",
+            "metadata": {
+            },
+            "name": "LONGSON/LONGBOB",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:40 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_check_transcript_scrubbing.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_check_transcript_scrubbing.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/tokens?bank_account%5Baccount_holder_name%5D=Jim%20Smith&bank_account%5Baccount_holder_type%5D=individual&bank_account%5Baccount_number%5D=000123456789&bank_account%5Bcountry%5D=US&bank_account%5Bcurrency%5D=usd&bank_account%5Brouting_number%5D=110000000
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 6ab5e89c-8cf5-4d68-9a62-0fe62c225e58
+      Original-Request:
+      - req_05AmmRDqpTotV6
+      Request-Id:
+      - req_05AmmRDqpTotV6
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "btok_1K6dl3AWOtgoysoghMsAxSnR",
+          "object": "token",
+          "bank_account": {
+            "id": "ba_1K6dl3AWOtgoysoglr6kMT23",
+            "object": "bank_account",
+            "account_holder_name": "Jim Smith",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "routing_number": "110000000",
+            "status": "new"
+          },
+          "client_ip": "181.51.32.190",
+          "created": 1639498901,
+          "livemode": false,
+          "type": "bank_account",
+          "used": false
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:41 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&source=btok_1K6dl3AWOtgoysoghMsAxSnR
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1269'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ca281393-0bea-4247-a76f-3ec32472f1de
+      Original-Request:
+      - req_85HL84MIIeUAc7
+      Request-Id:
+      - req_85HL84MIIeUAc7
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmC9jIXQSWX9Cz",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498901,
+          "currency": null,
+          "default_source": "ba_1K6dl3AWOtgoysoglr6kMT23",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "2882E185",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1K6dl3AWOtgoysoglr6kMT23",
+                "object": "bank_account",
+                "account_holder_name": "Jim Smith",
+                "account_holder_type": "individual",
+                "account_type": null,
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "customer": "cus_KmC9jIXQSWX9Cz",
+                "fingerprint": "uCkXlMFxqys7GosR",
+                "last4": "6789",
+                "metadata": {
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmC9jIXQSWX9Cz/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:42 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_creditcard_purchase_with_customer.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_creditcard_purchase_with_customer.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f90c59c1-50a1-4fa5-881c-cd763893c288
+      Original-Request:
+      - req_AcA23UgcMKO8Q8
+      Request-Id:
+      - req_AcA23UgcMKO8Q8
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dl5AWOtgoysog10kUgNxT",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dl5AWOtgoysog10ulqZ2H",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498903,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 34,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dl5AWOtgoysogqztXpc2w",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dl5AWOtgoysog10kUgNxT/rcpt_KmC9qkt0p7MA81IdSZiDy8Wt7cgSEKh",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dl5AWOtgoysog10kUgNxT/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dl5AWOtgoysogqztXpc2w",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:43 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_expanding_objects.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_expanding_objects.yml
@@ -1,0 +1,222 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&expand[0]=balance_transaction
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3727'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 8f9ec859-2c00-4f3d-8167-dd5ceaa55a4d
+      Original-Request:
+      - req_zPkBeD3kMv9AAM
+      Request-Id:
+      - req_zPkBeD3kMv9AAM
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dl6AWOtgoysog3Bdd95aZ",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": {
+            "id": "txn_3K6dl6AWOtgoysog3pXSUfRc",
+            "object": "balance_transaction",
+            "amount": 100,
+            "available_on": 1640044800,
+            "created": 1639498904,
+            "currency": "usd",
+            "description": "ActiveMerchant Test Purchase",
+            "exchange_rate": null,
+            "fee": 33,
+            "fee_details": [
+              {
+                "amount": 33,
+                "application": null,
+                "currency": "usd",
+                "description": "Stripe processing fees",
+                "type": "stripe_fee"
+              }
+            ],
+            "net": 67,
+            "reporting_category": "charge",
+            "source": "ch_3K6dl6AWOtgoysog3Bdd95aZ",
+            "status": "pending",
+            "type": "charge"
+          },
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498904,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 37,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dl6AWOtgoysogHftiUUMJ",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dl6AWOtgoysog3Bdd95aZ/rcpt_KmC9zJSVh9SYWDFH45JmARE2NYypqJt",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dl6AWOtgoysog3Bdd95aZ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dl6AWOtgoysogHftiUUMJ",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:45 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_expired_card_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_expired_card_for_purchase.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '253'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 41469af8-0cb3-414e-a1bc-5b3de515249d
+      Original-Request:
+      - req_fpi0YKAghPNp3E
+      Request-Id:
+      - req_fpi0YKAghPNp3E
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3K6dl8AWOtgoysog05g6ImXc",
+            "code": "expired_card",
+            "doc_url": "https://stripe.com/docs/error-codes/expired-card",
+            "message": "Your card has expired.",
+            "param": "exp_month",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:46 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_incorrect_cvc_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_incorrect_cvc_for_purchase.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '266'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - da426a42-5dd4-4667-9453-1ccfe477ee2a
+      Original-Request:
+      - req_uCl92zolXglf2M
+      Request-Id:
+      - req_uCl92zolXglf2M
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3K6dl9AWOtgoysog1QoP1YP2",
+            "code": "incorrect_cvc",
+            "doc_url": "https://stripe.com/docs/error-codes/incorrect-cvc",
+            "message": "Your card's security code is incorrect.",
+            "param": "cvc",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:48 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_incorrect_number_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_incorrect_number_for_purchase.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '221'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 40eefcc1-4d59-4e0e-9e45-21ae8ada39fc
+      Original-Request:
+      - req_G5C5UCCGU8YcvI
+      Request-Id:
+      - req_G5C5UCCGU8YcvI
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "incorrect_number",
+            "doc_url": "https://stripe.com/docs/error-codes/incorrect-number",
+            "message": "Your card number is incorrect.",
+            "param": "number",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:48 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_invalid_cvc_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_invalid_cvc_for_purchase.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=-1&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '215'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 475a2073-7db8-43c6-aff5-4ea7dd6d495b
+      Original-Request:
+      - req_II3LKVgpkNQnzc
+      Request-Id:
+      - req_II3LKVgpkNQnzc
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "invalid_cvc",
+            "doc_url": "https://stripe.com/docs/error-codes/invalid-cvc",
+            "message": "Your card's security code is invalid.",
+            "param": "cvc",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:49 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_invalid_expiry_month_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_invalid_expiry_month_for_purchase.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=16&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '242'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d9362dd7-6522-49d4-964a-4caacf60d758
+      Original-Request:
+      - req_PhIpStGwSeZfTU
+      Request-Id:
+      - req_PhIpStGwSeZfTU
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "invalid_expiry_month",
+            "doc_url": "https://stripe.com/docs/error-codes/invalid-expiry-month",
+            "message": "Your card's expiration month is invalid.",
+            "param": "exp_month",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:50 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_invalid_expiry_year_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_invalid_expiry_year_for_purchase.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=0&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '238'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 802cd82a-69e9-4ffd-920b-023ea32459d9
+      Original-Request:
+      - req_mWZPjjTxunONIl
+      Request-Id:
+      - req_mWZPjjTxunONIl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "invalid_expiry_year",
+            "doc_url": "https://stripe.com/docs/error-codes/invalid-expiry-year",
+            "message": "Your card's expiration year is invalid.",
+            "param": "exp_year",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:50 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_invalid_login.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_invalid_login.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Www-Authenticate:
+      - Basic realm="Stripe"
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Invalid API Key provided: active_m********test",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:51 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_invalid_number_for_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_invalid_number_for_purchase.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '237'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f324658d-00e4-405a-94ee-4d41ac2f54a2
+      Original-Request:
+      - req_KZ4Oc4l9KGqtf6
+      Request-Id:
+      - req_KZ4Oc4l9KGqtf6
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "invalid_number",
+            "doc_url": "https://stripe.com/docs/error-codes/invalid-number",
+            "message": "The card number is not a valid credit card number.",
+            "param": "number",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:52 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_processing_error.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_processing_error.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '285'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4b57a05f-acbe-45d5-adb6-b6eec8c81de0
+      Original-Request:
+      - req_2ai4sACVVxTApd
+      Request-Id:
+      - req_2ai4sACVVxTApd
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3K6dlEAWOtgoysog08CY8B3k",
+            "code": "processing_error",
+            "doc_url": "https://stripe.com/docs/error-codes/processing-error",
+            "message": "An error occurred while processing your card. Try again in a little bit.",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:53 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_purchase_with_connected_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_purchase_with_connected_account.yml
@@ -1,0 +1,202 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&on_behalf_of=acct_1K5HlrPT5iqVqrJn&transfer_data[destination]=acct_1K5HlrPT5iqVqrJn&transfer_group=XFERGROUP&application_fee_amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3325'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4fa7429e-bc6c-4faa-bd2e-57142eb8088b
+      Original-Request:
+      - req_1kyH7RmR02dodo
+      Request-Id:
+      - req_1kyH7RmR02dodo
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlGAWOtgoysog0nzHpoNK",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": "fee_1K6dlGPT5iqVqrJnPjTQ9JCe",
+          "application_fee_amount": 100,
+          "balance_transaction": "txn_3K6dlGAWOtgoysog0IFmlH0Y",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498914,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 2,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlFAWOtgoysogtS4gjKfg",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlGAWOtgoysog0nzHpoNK/rcpt_KmC9DnohVNKbUhbjZWleaa2U7DbcBTe",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlGAWOtgoysog0nzHpoNK/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlFAWOtgoysogtS4gjKfg",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dlGAWOtgoysog0cMle9p2",
+          "transfer_data": {
+            "amount": null,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "XFERGROUP"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:55 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_refund_with_reverse_transfer.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_refund_with_reverse_transfer.yml
@@ -1,0 +1,433 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:21:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3325'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 05aeb3a4-0cdb-433f-8ebb-6dde91d3ea23
+      Original-Request:
+      - req_M39JQQSuGc53cg
+      Request-Id:
+      - req_M39JQQSuGc53cg
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlIAWOtgoysog2gzNz9kD",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlIAWOtgoysog2wC13fme",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498916,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 23,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlIAWOtgoysogxvo74KQv",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlIAWOtgoysog2gzNz9kD/rcpt_KmC9ZaVpgR8rdSu0Uzdwgsgkyatx66Z",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlIAWOtgoysog2gzNz9kD/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlIAWOtgoysogxvo74KQv",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dlIAWOtgoysog2kf7Z0e8",
+          "transfer_data": {
+            "amount": null,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dlIAWOtgoysog2gzNz9kD"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:57 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dlIAWOtgoysog2gzNz9kD/refunds
+    body:
+      encoding: UTF-8
+      string: amount=80&reverse_transfer=true&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4555'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 9ba18ad6-cc27-4df6-ba4e-8454c47c96b5
+      Original-Request:
+      - req_hm2ueBjHOLpHy7
+      Request-Id:
+      - req_hm2ueBjHOLpHy7
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dlIAWOtgoysog29nx7ehg",
+          "object": "refund",
+          "amount": 80,
+          "balance_transaction": "txn_3K6dlIAWOtgoysog2Jl4xL92",
+          "charge": {
+            "id": "ch_3K6dlIAWOtgoysog2gzNz9kD",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 100,
+            "amount_refunded": 80,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_3K6dlIAWOtgoysog2wC13fme",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+            "captured": true,
+            "created": 1639498916,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": "acct_1K5HlrPT5iqVqrJn",
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 23,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dlIAWOtgoysogxvo74KQv",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlIAWOtgoysog2gzNz9kD/rcpt_KmC9ZaVpgR8rdSu0Uzdwgsgkyatx66Z",
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dlIAWOtgoysog29nx7ehg",
+                  "object": "refund",
+                  "amount": 80,
+                  "balance_transaction": "txn_3K6dlIAWOtgoysog2Jl4xL92",
+                  "charge": "ch_3K6dlIAWOtgoysog2gzNz9kD",
+                  "created": 1639498918,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": "trr_1K6dlLAWOtgoysog8KPZs0cG"
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dlIAWOtgoysog2gzNz9kD/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dlIAWOtgoysogxvo74KQv",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer": "tr_3K6dlIAWOtgoysog2kf7Z0e8",
+            "transfer_data": {
+              "amount": null,
+              "destination": "acct_1K5HlrPT5iqVqrJn"
+            },
+            "transfer_group": "group_ch_3K6dlIAWOtgoysog2gzNz9kD"
+          },
+          "created": 1639498918,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": "trr_1K6dlLAWOtgoysog8KPZs0cG"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:21:59 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_statement_description.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_statement_description.yml
@@ -1,0 +1,197 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&statement_descriptor=Eggcellent+Description
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3134'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 95aaf0fd-e754-4720-b38a-17c83264bc2d
+      Original-Request:
+      - req_Rh3MQzbQZklFB0
+      Request-Id:
+      - req_Rh3MQzbQZklFB0
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlMAWOtgoysog2dCx44cY",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlMAWOtgoysog29Eh4QZl",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY* EGGCELLENT D",
+          "captured": true,
+          "created": 1639498920,
+          "currency": "usd",
+          "customer": null,
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 31,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlMAWOtgoysogL1ln5deS",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlMAWOtgoysog2dCx44cY/rcpt_KmC953N0psPbfK4BFYswcJwySVVUn2W",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlMAWOtgoysog2dCx44cY/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlMAWOtgoysogL1ln5deS",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": "Eggcellent Description",
+          "statement_descriptor_suffix": "Eggcellent Description",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:01 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_statement_descriptor_suffix.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_statement_descriptor_suffix.yml
@@ -1,0 +1,197 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&statement_descriptor_suffix=SUFFIX
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3092'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 8145e637-aa51-4912-a11a-314dc4d56c98
+      Original-Request:
+      - req_wXW9xgL5FBcgDO
+      Request-Id:
+      - req_wXW9xgL5FBcgDO
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlOAWOtgoysog2QBa0PI6",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlOAWOtgoysog2SOEbgYR",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY* SUFFIX",
+          "captured": true,
+          "created": 1639498922,
+          "currency": "usd",
+          "customer": null,
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 59,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlOAWOtgoysogFudynXDo",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlOAWOtgoysog2QBa0PI6/rcpt_KmC9CIDSiTwzJskFYQqHu8yBtNPMtU7",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlOAWOtgoysog2QBa0PI6/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlOAWOtgoysogFudynXDo",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": "SUFFIX",
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:02 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_stripe_account_header.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_stripe_account_header.yml
@@ -1,0 +1,200 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Stripe-Account:
+      - acct_1K5HlrPT5iqVqrJn
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3100'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 290f1113-5091-40f0-a693-07fe14c956bd
+      Original-Request:
+      - req_r2TnM65Tqvma3D
+      Request-Id:
+      - req_r2TnM65Tqvma3D
+      Stripe-Account:
+      - acct_1K5HlrPT5iqVqrJn
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlPPT5iqVqrJn05mFRgxR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": "ca_6E9gvTfZGEMknxpoHhC8xoeyMit55FAV",
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlPPT5iqVqrJn0d1YDfhp",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498923,
+          "currency": "usd",
+          "customer": null,
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 49,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlPPT5iqVqrJnuw4UKr07",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1075257731158076",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_1K5HlrPT5iqVqrJn/ch_3K6dlPPT5iqVqrJn05mFRgxR/rcpt_KmC9Jqbo4XCoY9X3NgdDvSouvrkqyDr",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlPPT5iqVqrJn05mFRgxR/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlPPT5iqVqrJnuw4UKr07",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:04 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_authorization_and_capture_with_radar_session.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_authorization_and_capture_with_radar_session.yml
@@ -1,0 +1,399 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&radar_options[session]=rse_1JXSfZAWOtgoysogUpPJa4sm&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3181'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - b6d88c4f-d0f1-45a4-bbee-880e01e9751a
+      Original-Request:
+      - req_cPAK6MyS5IMoW5
+      Request-Id:
+      - req_cPAK6MyS5IMoW5
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlRAWOtgoysog0sjBTybr",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498925,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 1,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlRAWOtgoysogynMFWiZh",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {
+            "session": "rse_1JXSfZAWOtgoysogUpPJa4sm"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlRAWOtgoysog0sjBTybr/rcpt_KmC9aCNDK5S4icH3zVEmQO1xmRoE0fU",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlRAWOtgoysog0sjBTybr/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlRAWOtgoysogynMFWiZh",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:06 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dlRAWOtgoysog0sjBTybr/capture
+    body:
+      encoding: UTF-8
+      string: amount=100
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3208'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ccf2c13d-71f6-4100-b4c0-29ac0644ffe5
+      Original-Request:
+      - req_7PwpHDOpR24brf
+      Request-Id:
+      - req_7PwpHDOpR24brf
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlRAWOtgoysog0sjBTybr",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlRAWOtgoysog0s7JtLuG",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498925,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 1,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlRAWOtgoysogynMFWiZh",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {
+            "session": "rse_1JXSfZAWOtgoysogUpPJa4sm"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlRAWOtgoysog0sjBTybr/rcpt_KmC9aCNDK5S4icH3zVEmQO1xmRoE0fU",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlRAWOtgoysog0sjBTybr/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlRAWOtgoysogynMFWiZh",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:07 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_echeck_purchase_with_verified_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_echeck_purchase_with_verified_account.yml
@@ -1,0 +1,174 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_7s22nNueP2Hjj6&card=ba_17cHxeAWOtgoysogv3NM8CJ1&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2467'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f5962702-a74f-456e-95e9-b9439c6779f9
+      Original-Request:
+      - req_o3b67G0Qqnswy5
+      Request-Id:
+      - req_o3b67G0Qqnswy5
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "py_1K6dlUAWOtgoysog3pkqVk3U",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_1K6dlUAWOtgoysogLGJ7fctM",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "calculated_statement_descriptor": null,
+          "captured": true,
+          "created": 1639498928,
+          "currency": "usd",
+          "customer": "cus_7s22nNueP2Hjj6",
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "not_assessed",
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": false,
+          "payment_intent": null,
+          "payment_method": null,
+          "payment_method_details": {
+            "ach_debit": {
+              "account_holder_type": "individual",
+              "bank_name": "STRIPE TEST BANK",
+              "country": "US",
+              "fingerprint": "uCkXlMFxqys7GosR",
+              "last4": "6789",
+              "routing_number": "110000000"
+            },
+            "type": "ach_debit"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": null,
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/py_1K6dlUAWOtgoysog3pkqVk3U/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "ba_17cHxeAWOtgoysogv3NM8CJ1",
+            "object": "bank_account",
+            "account_holder_name": "STRIPE TEST BANK",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "customer": "cus_7s22nNueP2Hjj6",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "metadata": {
+            },
+            "routing_number": "110000000",
+            "status": "verified"
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "pending",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:08 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - '078c40c1-52cf-4ae5-a796-4cac5f3aaa2e'
+      Original-Request:
+      - req_r8BRL7FWOXIhSg
+      Request-Id:
+      - req_r8BRL7FWOXIhSg
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlVAWOtgoysog3WMnL1tv",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlVAWOtgoysog3v3AcmAr",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498929,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 49,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlVAWOtgoysogYJn8VtU5",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlVAWOtgoysog3WMnL1tv/rcpt_KmC9iePojDSCAdF8pAkDuSWfn8Esy3I",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlVAWOtgoysog3WMnL1tv/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlVAWOtgoysogYJn8VtU5",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:10 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_from_stored_and_verified_bank_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_from_stored_and_verified_bank_account.yml
@@ -1,0 +1,473 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/tokens?bank_account%5Baccount_holder_name%5D=Jim%20Smith&bank_account%5Baccount_holder_type%5D=individual&bank_account%5Baccount_number%5D=000123456789&bank_account%5Bcountry%5D=US&bank_account%5Bcurrency%5D=usd&bank_account%5Brouting_number%5D=110000000
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 7a7f6c6f-6139-4ff1-bb66-5e0169da8534
+      Original-Request:
+      - req_7RmyAFlj1nZ7uN
+      Request-Id:
+      - req_7RmyAFlj1nZ7uN
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "btok_1K6dlWAWOtgoysog2Cj2lAjd",
+          "object": "token",
+          "bank_account": {
+            "id": "ba_1K6dlWAWOtgoysogLWl4nI5C",
+            "object": "bank_account",
+            "account_holder_name": "Jim Smith",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "routing_number": "110000000",
+            "status": "new"
+          },
+          "client_ip": "181.51.32.190",
+          "created": 1639498930,
+          "livemode": false,
+          "type": "bank_account",
+          "used": false
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:10 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&source=btok_1K6dlWAWOtgoysog2Cj2lAjd
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1269'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 513ff15f-9268-4ba0-acb5-23c881d7cd50
+      Original-Request:
+      - req_arzmEqeH6wyP9Q
+      Request-Id:
+      - req_arzmEqeH6wyP9Q
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmC9xR6ORoLjr7",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498931,
+          "currency": null,
+          "default_source": "ba_1K6dlWAWOtgoysogLWl4nI5C",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "4ACC29C8",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1K6dlWAWOtgoysogLWl4nI5C",
+                "object": "bank_account",
+                "account_holder_name": "Jim Smith",
+                "account_holder_type": "individual",
+                "account_type": null,
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "customer": "cus_KmC9xR6ORoLjr7",
+                "fingerprint": "uCkXlMFxqys7GosR",
+                "last4": "6789",
+                "metadata": {
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmC9xR6ORoLjr7/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:12 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers/cus_KmC9xR6ORoLjr7/sources/ba_1K6dlWAWOtgoysogLWl4nI5C/verify
+    body:
+      encoding: UTF-8
+      string: amounts[0]=32&amounts[1]=45
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '416'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 7385a2c5-4cfb-47cb-9be0-d5702c3f78a8
+      Original-Request:
+      - req_nAice46MzGfSTE
+      Request-Id:
+      - req_nAice46MzGfSTE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ba_1K6dlWAWOtgoysogLWl4nI5C",
+          "object": "bank_account",
+          "account_holder_name": "Jim Smith",
+          "account_holder_type": "individual",
+          "account_type": null,
+          "bank_name": "STRIPE TEST BANK",
+          "country": "US",
+          "currency": "usd",
+          "customer": "cus_KmC9xR6ORoLjr7",
+          "fingerprint": "uCkXlMFxqys7GosR",
+          "last4": "6789",
+          "metadata": {
+          },
+          "routing_number": "110000000",
+          "status": "verified"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:12 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_KmC9xR6ORoLjr7&card=ba_1K6dlWAWOtgoysogLWl4nI5C&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2460'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - df1dc440-0305-4fda-8cbc-1e7ef3908055
+      Original-Request:
+      - req_sfbYE7c7eiHI1K
+      Request-Id:
+      - req_sfbYE7c7eiHI1K
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "py_1K6dlZAWOtgoysogecvvqWgl",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_1K6dlZAWOtgoysogLLdsHJT4",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "calculated_statement_descriptor": null,
+          "captured": true,
+          "created": 1639498933,
+          "currency": "usd",
+          "customer": "cus_KmC9xR6ORoLjr7",
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "not_assessed",
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": false,
+          "payment_intent": null,
+          "payment_method": null,
+          "payment_method_details": {
+            "ach_debit": {
+              "account_holder_type": "individual",
+              "bank_name": "STRIPE TEST BANK",
+              "country": "US",
+              "fingerprint": "uCkXlMFxqys7GosR",
+              "last4": "6789",
+              "routing_number": "110000000"
+            },
+            "type": "ach_debit"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": null,
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/py_1K6dlZAWOtgoysogecvvqWgl/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "ba_1K6dlWAWOtgoysogLWl4nI5C",
+            "object": "bank_account",
+            "account_holder_name": "Jim Smith",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "customer": "cus_KmC9xR6ORoLjr7",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "metadata": {
+            },
+            "routing_number": "110000000",
+            "status": "verified"
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "pending",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:14 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card.yml
@@ -1,0 +1,329 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1507'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f804f63c-16ba-4458-871e-cd8290322e43
+      Original-Request:
+      - req_NPCvajbpfiBNZ7
+      Request-Id:
+      - req_NPCvajbpfiBNZ7
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmC9AmqCTHLjVi",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498934,
+          "currency": null,
+          "default_source": "card_1K6dlaAWOtgoysogSZOCBsM5",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "61546156",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dlaAWOtgoysogSZOCBsM5",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmC9AmqCTHLjVi",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmC9AmqCTHLjVi/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_KmC9AmqCTHLjVi&card=card_1K6dlaAWOtgoysogSZOCBsM5&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3111'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4343c810-274b-425b-908f-045e4558012d
+      Original-Request:
+      - req_5Bjh8kfJfWJOPY
+      Request-Id:
+      - req_5Bjh8kfJfWJOPY
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlcAWOtgoysog0R6ytpdl",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlcAWOtgoysog0e1h7NMY",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498936,
+          "currency": "usd",
+          "customer": "cus_KmC9AmqCTHLjVi",
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 2,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlaAWOtgoysogSZOCBsM5",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlcAWOtgoysog0R6ytpdl/rcpt_KmC9mmFia9R8oWYM9QRmKx70b9iLpf6",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlcAWOtgoysog0R6ytpdl/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlaAWOtgoysogSZOCBsM5",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_KmC9AmqCTHLjVi",
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:17 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card_on_existing_customer.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card_on_existing_customer.yml
@@ -1,0 +1,423 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1507'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 3ab10e4f-f7ba-49ec-984f-03a57f2b7c60
+      Original-Request:
+      - req_bxs5drcOjYTGtR
+      Request-Id:
+      - req_bxs5drcOjYTGtR
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmC9txx7WefQxh",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498937,
+          "currency": null,
+          "default_source": "card_1K6dldAWOtgoysogNznkrEN8",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "4ECBB81D",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dldAWOtgoysogNznkrEN8",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmC9txx7WefQxh",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmC9txx7WefQxh/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:18 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers/cus_KmC9txx7WefQxh/cards
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '600'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 44f4f171-429f-4c06-9ed3-12b7558b4b26
+      Original-Request:
+      - req_LHZECgg39d6o0F
+      Request-Id:
+      - req_LHZECgg39d6o0F
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dlfAWOtgoysog28X5XaBf",
+          "object": "card",
+          "address_city": null,
+          "address_country": null,
+          "address_line1": null,
+          "address_line1_check": null,
+          "address_line2": null,
+          "address_state": null,
+          "address_zip": null,
+          "address_zip_check": null,
+          "brand": "MasterCard",
+          "country": "US",
+          "customer": "cus_KmC9txx7WefQxh",
+          "cvc_check": "pass",
+          "dynamic_last4": null,
+          "exp_month": 9,
+          "exp_year": 2022,
+          "fingerprint": "CIexiIsKcjMWabUj",
+          "funding": "prepaid",
+          "last4": "5100",
+          "metadata": {
+          },
+          "name": "Longbob Longsen",
+          "tokenization_method": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_KmC9txx7WefQxh&card=card_1K6dlfAWOtgoysog28X5XaBf&amount=100&currency=usd&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3129'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 2f9ebbaa-e2ed-4768-8b49-0ccacb853d93
+      Original-Request:
+      - req_HujvlhQEv250Vi
+      Request-Id:
+      - req_HujvlhQEv250Vi
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlgAWOtgoysog1Ul9U6kT",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlgAWOtgoysog1dyluAvK",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498940,
+          "currency": "usd",
+          "customer": "cus_KmC9txx7WefQxh",
+          "description": null,
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 39,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlfAWOtgoysog28X5XaBf",
+          "payment_method_details": {
+            "card": {
+              "brand": "mastercard",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "CIexiIsKcjMWabUj",
+              "funding": "prepaid",
+              "installments": null,
+              "last4": "5100",
+              "mandate": null,
+              "moto": null,
+              "network": "mastercard",
+              "network_transaction_id": "MCCCIEXII1214",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlgAWOtgoysog1Ul9U6kT/rcpt_KmCAwrgS0EFDQkO5uC31qkDC7dXzy1w",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlgAWOtgoysog1Ul9U6kT/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlfAWOtgoysog28X5XaBf",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "MasterCard",
+            "country": "US",
+            "customer": "cus_KmC9txx7WefQxh",
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "CIexiIsKcjMWabUj",
+            "funding": "prepaid",
+            "last4": "5100",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:21 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card_with_customer_id.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_using_stored_card_with_customer_id.yml
@@ -1,0 +1,330 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1507'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d755dac1-b12c-4b5b-87af-09647b623111
+      Original-Request:
+      - req_tzBNIYyP8yVdIl
+      Request-Id:
+      - req_tzBNIYyP8yVdIl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCA2mJjA7VeHd",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498942,
+          "currency": null,
+          "default_source": "card_1K6dliAWOtgoysog113IImCK",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "6F10E596",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dliAWOtgoysog113IImCK",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCA2mJjA7VeHd",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCA2mJjA7VeHd/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:23 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&customer=cus_KmCA2mJjA7VeHd&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3168'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 82879f5e-529f-4e62-8a3b-a45b00b3352b
+      Original-Request:
+      - req_LR8HnK4cWe5ho1
+      Request-Id:
+      - req_LR8HnK4cWe5ho1
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dljAWOtgoysog1Kyzrdc7",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dljAWOtgoysog1ToIb4GF",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498943,
+          "currency": "usd",
+          "customer": "cus_KmCA2mJjA7VeHd",
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 5,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dliAWOtgoysog113IImCK",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dljAWOtgoysog1Kyzrdc7/rcpt_KmCAy916IM5jMj2F5Uwh5zRuPVxMtFI",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dljAWOtgoysog1Kyzrdc7/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dliAWOtgoysog113IImCK",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": "cus_KmCA2mJjA7VeHd",
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:24 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_blank_referer.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_blank_referer.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3136'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 2620aea7-2531-42a7-a0ea-385481827059
+      Original-Request:
+      - req_WmYMwzvYOijiBH
+      Request-Id:
+      - req_WmYMwzvYOijiBH
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dllAWOtgoysog1Z2z6dlG",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dllAWOtgoysog1GBUqiMq",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498945,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 4,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dllAWOtgoysog1vpZgNEy",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dllAWOtgoysog1Z2z6dlG/rcpt_KmCAp6X4syaa4ABBSrtkySwJtfZ2j0D",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dllAWOtgoysog1Z2z6dlG/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dllAWOtgoysog1vpZgNEy",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:26 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_destination.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_destination.yml
@@ -1,0 +1,202 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3325'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 2dff319b-b85c-405a-90c9-82297c064267
+      Original-Request:
+      - req_vbnLZrV1qAkh4b
+      Request-Id:
+      - req_vbnLZrV1qAkh4b
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlnAWOtgoysog3ogUxlMz",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlnAWOtgoysog3P2MC4y2",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498947,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 42,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlnAWOtgoysogGkCnmf2G",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlnAWOtgoysog3ogUxlMz/rcpt_KmCAXznv9ZM7TmN1GhP1BIZTXTntdwh",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlnAWOtgoysog3ogUxlMz/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlnAWOtgoysogGkCnmf2G",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dlnAWOtgoysog3STE8TgC",
+          "transfer_data": {
+            "amount": null,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dlnAWOtgoysog3ogUxlMz"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:28 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_destination_and_amount.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_destination_and_amount.yml
@@ -1,0 +1,202 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn&destination[amount]=80
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3323'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f990ae9f-e4df-4186-af1a-95519edc525b
+      Original-Request:
+      - req_lYkALz906HQeCe
+      Request-Id:
+      - req_lYkALz906HQeCe
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlpAWOtgoysog0EAjAmV6",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlpAWOtgoysog0ZDH88NG",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "WWW.JOHNDOEWEB.COM",
+          "captured": true,
+          "created": 1639498949,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": "acct_1K5HlrPT5iqVqrJn",
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": "acct_1K5HlrPT5iqVqrJn",
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 17,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlpAWOtgoysogBv2xjL1R",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlpAWOtgoysog0EAjAmV6/rcpt_KmCAp0g5CkLa13YGKad7H1a66FFm0o1",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlpAWOtgoysog0EAjAmV6/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlpAWOtgoysogBv2xjL1R",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer": "tr_3K6dlpAWOtgoysog0qUquljI",
+          "transfer_data": {
+            "amount": 80,
+            "destination": "acct_1K5HlrPT5iqVqrJn"
+          },
+          "transfer_group": "group_ch_3K6dlpAWOtgoysog0EAjAmV6"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:30 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_level3_data.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_level3_data.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&level3[merchant_reference]=123&level3[customer_reference]=456&level3[shipping_address_zip]=98765&level3[shipping_from_zip]=54321&level3[shipping_amount]=10&level3[line_items][0][product_code]=1234&level3[line_items][0][product_description]=An+item&level3[line_items][0][unit_cost]=15&level3[line_items][0][quantity]=2&level3[line_items][0][tax_amount]=0&level3[line_items][1][product_code]=999&level3[line_items][1][product_description]=A+totes+different+item&level3[line_items][1][tax_amount]=10&level3[line_items][1][unit_cost]=50&level3[line_items][1][quantity]=1
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3136'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ff369dfb-d7a5-468a-9599-c38074d31f36
+      Original-Request:
+      - req_vyFwZgEIjJ32fq
+      Request-Id:
+      - req_vyFwZgEIjJ32fq
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlrAWOtgoysog1e7whWAN",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlrAWOtgoysog1e4AajE8",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498951,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 3,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlrAWOtgoysogVUAjAStj",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlrAWOtgoysog1e7whWAN/rcpt_KmCAANKiRrCgXQY5zE9rMbvC7ZZxN9j",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlrAWOtgoysog1e7whWAN/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlrAWOtgoysogVUAjAStj",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:32 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_radar_session.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_radar_session.yml
@@ -1,0 +1,201 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&radar_options[session]=rse_1JXSfZAWOtgoysogUpPJa4sm
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3209'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 6aceec79-d747-4f40-bb70-43893267ff2f
+      Original-Request:
+      - req_PmTnZfycCXbUld
+      Request-Id:
+      - req_PmTnZfycCXbUld
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dltAWOtgoysog1mdAxGO0",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dltAWOtgoysog1T7UAvif",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498953,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dltAWOtgoysogsJfHWzi3",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "radar_options": {
+            "session": "rse_1JXSfZAWOtgoysogUpPJa4sm"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dltAWOtgoysog1mdAxGO0/rcpt_KmCAzYQBv04bksiSQ8PdoMMiTD76JiS",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dltAWOtgoysog1mdAxGO0/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dltAWOtgoysogsJfHWzi3",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:34 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_recurring_flag.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_purchase_with_recurring_flag.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&recurring=true&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:36 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 12658ddc-3443-444f-999e-cfb811895487
+      Original-Request:
+      - req_15oWVYSycRRurb
+      Request-Id:
+      - req_15oWVYSycRRurb
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlvAWOtgoysog1Nv77XPG",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlvAWOtgoysog1kruu5pq",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498955,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 60,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dluAWOtgoysogT2n4w6hl",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlvAWOtgoysog1Nv77XPG/rcpt_KmCA8ZZ9uJVj7xgJXuBwAshOsrYeanR",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlvAWOtgoysog1Nv77XPG/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dluAWOtgoysogT2n4w6hl",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:36 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_refund.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_refund.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 15352523-ba76-463b-99f3-50d00af05eb6
+      Original-Request:
+      - req_ElAI20PZFNIyRM
+      Request-Id:
+      - req_ElAI20PZFNIyRM
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dlwAWOtgoysog3H11b2wV",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dlwAWOtgoysog3p1USUet",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498956,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 27,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dlwAWOtgoysog2DXjh4OH",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlwAWOtgoysog3H11b2wV/rcpt_KmCAAMYuKg9UCZv0JWvCbAqMvGg2csy",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dlwAWOtgoysog3H11b2wV/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dlwAWOtgoysog2DXjh4OH",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:37 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dlwAWOtgoysog3H11b2wV/refunds
+    body:
+      encoding: UTF-8
+      string: amount=80&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4307'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - e7ea7ff4-ffda-45ab-a3bb-022928ab5c3c
+      Original-Request:
+      - req_yqDPr6r8ut9QcS
+      Request-Id:
+      - req_yqDPr6r8ut9QcS
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dlwAWOtgoysog3qhCSkbC",
+          "object": "refund",
+          "amount": 80,
+          "balance_transaction": "txn_3K6dlwAWOtgoysog31rajjgq",
+          "charge": {
+            "id": "ch_3K6dlwAWOtgoysog3H11b2wV",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 100,
+            "amount_refunded": 80,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_3K6dlwAWOtgoysog3p1USUet",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": true,
+            "created": 1639498956,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 27,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dlwAWOtgoysog2DXjh4OH",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dlwAWOtgoysog3H11b2wV/rcpt_KmCAAMYuKg9UCZv0JWvCbAqMvGg2csy",
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dlwAWOtgoysog3qhCSkbC",
+                  "object": "refund",
+                  "amount": 80,
+                  "balance_transaction": "txn_3K6dlwAWOtgoysog31rajjgq",
+                  "charge": "ch_3K6dlwAWOtgoysog3H11b2wV",
+                  "created": 1639498958,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dlwAWOtgoysog3H11b2wV/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dlwAWOtgoysog2DXjh4OH",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498958,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:38 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_refund_on_verified_bank_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_refund_on_verified_bank_account.yml
@@ -1,0 +1,377 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_7s22nNueP2Hjj6&card=ba_17cHxeAWOtgoysogv3NM8CJ1&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2467'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 073fd6d9-cb5d-4471-92f0-e59470978cb3
+      Original-Request:
+      - req_F7YKfZPgQzoUyZ
+      Request-Id:
+      - req_F7YKfZPgQzoUyZ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "py_1K6dlzAWOtgoysog649y7A4l",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_1K6dlzAWOtgoysogZ1SYLyto",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": null,
+            "phone": null
+          },
+          "calculated_statement_descriptor": null,
+          "captured": true,
+          "created": 1639498959,
+          "currency": "usd",
+          "customer": "cus_7s22nNueP2Hjj6",
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "not_assessed",
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": false,
+          "payment_intent": null,
+          "payment_method": null,
+          "payment_method_details": {
+            "ach_debit": {
+              "account_holder_type": "individual",
+              "bank_name": "STRIPE TEST BANK",
+              "country": "US",
+              "fingerprint": "uCkXlMFxqys7GosR",
+              "last4": "6789",
+              "routing_number": "110000000"
+            },
+            "type": "ach_debit"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": null,
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/py_1K6dlzAWOtgoysog649y7A4l/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "ba_17cHxeAWOtgoysogv3NM8CJ1",
+            "object": "bank_account",
+            "account_holder_name": "STRIPE TEST BANK",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "customer": "cus_7s22nNueP2Hjj6",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "metadata": {
+            },
+            "routing_number": "110000000",
+            "status": "verified"
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "pending",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:40 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/py_1K6dlzAWOtgoysog649y7A4l/refunds
+    body:
+      encoding: UTF-8
+      string: amount=100&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3706'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 5937c3ba-7541-44a5-b51b-7cc3b6b12be3
+      Original-Request:
+      - req_zubo8Pv3rj3o7D
+      Request-Id:
+      - req_zubo8Pv3rj3o7D
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "pyr_1K6dm0AWOtgoysogdiHLZ1Uz",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_1K6dm1AWOtgoysogDfSu0fUv",
+          "charge": {
+            "id": "py_1K6dlzAWOtgoysog649y7A4l",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 100,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_1K6dlzAWOtgoysogZ1SYLyto",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+            },
+            "calculated_statement_descriptor": null,
+            "captured": true,
+            "created": 1639498959,
+            "currency": "usd",
+            "customer": "cus_7s22nNueP2Hjj6",
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "not_assessed",
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": null,
+            "payment_method_details": {
+              "ach_debit": {
+                "account_holder_type": "individual",
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "fingerprint": "uCkXlMFxqys7GosR",
+                "last4": "6789",
+                "routing_number": "110000000"
+              },
+              "type": "ach_debit"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/py_1K6dlzAWOtgoysog649y7A4l/rcpt_KmCAF6121gS6bqUvcO6rrMurPSffvOL",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "pyr_1K6dm0AWOtgoysogdiHLZ1Uz",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": "txn_1K6dm1AWOtgoysogDfSu0fUv",
+                  "charge": "py_1K6dlzAWOtgoysog649y7A4l",
+                  "created": 1639498960,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "pending",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/py_1K6dlzAWOtgoysog649y7A4l/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "ba_17cHxeAWOtgoysogv3NM8CJ1",
+              "object": "bank_account",
+              "account_holder_name": "STRIPE TEST BANK",
+              "account_holder_type": "individual",
+              "account_type": null,
+              "bank_name": "STRIPE TEST BANK",
+              "country": "US",
+              "currency": "usd",
+              "customer": "cus_7s22nNueP2Hjj6",
+              "fingerprint": "uCkXlMFxqys7GosR",
+              "last4": "6789",
+              "metadata": {
+              },
+              "routing_number": "110000000",
+              "status": "verified"
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498960,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "pending",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:41 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_refund_with_reason.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_refund_with_reason.yml
@@ -1,0 +1,426 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 3214e95f-8af6-4dc2-9f08-7f82f9f974b5
+      Original-Request:
+      - req_Csw3IbaMXT80h4
+      Request-Id:
+      - req_Csw3IbaMXT80h4
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dm2AWOtgoysog1ktkbvrR",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dm2AWOtgoysog1sZqqq8j",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639498962,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 10,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dm1AWOtgoysog0H8q5ql9",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dm2AWOtgoysog1ktkbvrR/rcpt_KmCAzr3kKGycyY1addF914VpXhXZPjr",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dm2AWOtgoysog1ktkbvrR/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dm1AWOtgoysog0H8q5ql9",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:42 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dm2AWOtgoysog1ktkbvrR/refunds
+    body:
+      encoding: UTF-8
+      string: amount=80&reason=fraudulent&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4357'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 9bc22c47-8a71-4034-a17a-17708f28346a
+      Original-Request:
+      - req_VgcdhgHPO16fFc
+      Request-Id:
+      - req_VgcdhgHPO16fFc
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dm2AWOtgoysog1ji3R1EG",
+          "object": "refund",
+          "amount": 80,
+          "balance_transaction": "txn_3K6dm2AWOtgoysog13jINwIp",
+          "charge": {
+            "id": "ch_3K6dm2AWOtgoysog1ktkbvrR",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 100,
+            "amount_refunded": 80,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_3K6dm2AWOtgoysog1sZqqq8j",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": true,
+            "created": 1639498962,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+              "user_report": "fraudulent"
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 10,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dm1AWOtgoysog0H8q5ql9",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dm2AWOtgoysog1ktkbvrR/rcpt_KmCAzr3kKGycyY1addF914VpXhXZPjr",
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dm2AWOtgoysog1ji3R1EG",
+                  "object": "refund",
+                  "amount": 80,
+                  "balance_transaction": "txn_3K6dm2AWOtgoysog13jINwIp",
+                  "charge": "ch_3K6dm2AWOtgoysog1ktkbvrR",
+                  "created": 1639498963,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": "fraudulent",
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dm2AWOtgoysog1ktkbvrR/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dm1AWOtgoysog0H8q5ql9",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498963,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:44 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_store.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_store.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=TheDescription&email=email%40example.com&expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1534'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d4bf195b-b839-49c3-b39b-be83364e5d29
+      Original-Request:
+      - req_syxtTcWHwiT6GL
+      Request-Id:
+      - req_syxtTcWHwiT6GL
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAcizCpTuIcB",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498964,
+          "currency": null,
+          "default_source": "card_1K6dm4AWOtgoysog7gPbTvMN",
+          "delinquent": false,
+          "description": "TheDescription",
+          "discount": null,
+          "email": "email@example.com",
+          "invoice_prefix": "4DC4BB84",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dm4AWOtgoysog7gPbTvMN",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAcizCpTuIcB",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAcizCpTuIcB/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:45 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_store_of_bank_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_store_of_bank_account.yml
@@ -1,0 +1,217 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/tokens?bank_account%5Baccount_holder_name%5D=Jim%20Smith&bank_account%5Baccount_holder_type%5D=individual&bank_account%5Baccount_number%5D=000123456789&bank_account%5Bcountry%5D=US&bank_account%5Bcurrency%5D=usd&bank_account%5Brouting_number%5D=110000000
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ece2abff-6874-4334-b8b8-3be4bc231b07
+      Original-Request:
+      - req_z2QW2hPuwrHFmt
+      Request-Id:
+      - req_z2QW2hPuwrHFmt
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "btok_1K6dm6AWOtgoysogPFt9eox2",
+          "object": "token",
+          "bank_account": {
+            "id": "ba_1K6dm6AWOtgoysog9FwsCxTB",
+            "object": "bank_account",
+            "account_holder_name": "Jim Smith",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "routing_number": "110000000",
+            "status": "new"
+          },
+          "client_ip": "181.51.32.190",
+          "created": 1639498966,
+          "livemode": false,
+          "type": "bank_account",
+          "used": false
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:46 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=ActiveMerchant+Test+Purchase&email=wow%40example.com&expand[0]=sources&source=btok_1K6dm6AWOtgoysogPFt9eox2
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1308'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - b7cb0f37-abfb-4dac-a904-21981bd112ca
+      Original-Request:
+      - req_W1k5wsBCMVo21Y
+      Request-Id:
+      - req_W1k5wsBCMVo21Y
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAxKSeJFphfv",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498966,
+          "currency": null,
+          "default_source": "ba_1K6dm6AWOtgoysog9FwsCxTB",
+          "delinquent": false,
+          "description": "ActiveMerchant Test Purchase",
+          "discount": null,
+          "email": "wow@example.com",
+          "invoice_prefix": "59C01186",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1K6dm6AWOtgoysog9FwsCxTB",
+                "object": "bank_account",
+                "account_holder_name": "Jim Smith",
+                "account_holder_type": "individual",
+                "account_type": null,
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "customer": "cus_KmCAxKSeJFphfv",
+                "fingerprint": "uCkXlMFxqys7GosR",
+                "last4": "6789",
+                "metadata": {
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAxKSeJFphfv/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:47 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_existing_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_existing_account.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/accounts/acct_1K5HlrPT5iqVqrJn/external_accounts
+    body:
+      encoding: UTF-8
+      string: external_account[object]=card&external_account[currency]=usd&external_account[number]=4000056655665556&external_account[exp_month]=9&external_account[exp_year]=2022&external_account[cvc]=123&external_account[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '715'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ababddc4-4f7e-4996-ad9f-acda98177ba1
+      Original-Request:
+      - req_kv21PwaVuDKJHj
+      Request-Id:
+      - req_kv21PwaVuDKJHj
+      Stripe-Account:
+      - acct_1K5HlrPT5iqVqrJn
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dm8PT5iqVqrJn7j5hejgj",
+          "object": "card",
+          "account": "acct_1K5HlrPT5iqVqrJn",
+          "address_city": null,
+          "address_country": null,
+          "address_line1": null,
+          "address_line1_check": null,
+          "address_line2": null,
+          "address_state": null,
+          "address_zip": null,
+          "address_zip_check": null,
+          "available_payout_methods": [
+            "standard",
+            "instant"
+          ],
+          "brand": "Visa",
+          "country": "US",
+          "currency": "usd",
+          "cvc_check": "pass",
+          "default_for_currency": false,
+          "dynamic_last4": null,
+          "exp_month": 9,
+          "exp_year": 2022,
+          "fingerprint": "OdTRtGskBulROtqa",
+          "funding": "debit",
+          "last4": "5556",
+          "metadata": {
+          },
+          "name": "Longbob Longsen",
+          "tokenization_method": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:49 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_existing_customer.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_existing_customer.yml
@@ -1,0 +1,387 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1507'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4bc9e139-efea-48c1-aac4-f5afa1a93ec4
+      Original-Request:
+      - req_yHtMGtfaOE4Pmf
+      Request-Id:
+      - req_yHtMGtfaOE4Pmf
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAau6IU8J5l4",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498970,
+          "currency": null,
+          "default_source": "card_1K6dmAAWOtgoysoghviqqYnB",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "AF25E40C",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmAAWOtgoysoghviqqYnB",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAau6IU8J5l4",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAau6IU8J5l4/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:50 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers/cus_KmCAau6IU8J5l4/cards
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '600'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d9c46894-b914-44d8-8954-7d678bcb59e6
+      Original-Request:
+      - req_ieuUlUp0nM3HKs
+      Request-Id:
+      - req_ieuUlUp0nM3HKs
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dmBAWOtgoysogSaH1eTeH",
+          "object": "card",
+          "address_city": null,
+          "address_country": null,
+          "address_line1": null,
+          "address_line1_check": null,
+          "address_line2": null,
+          "address_state": null,
+          "address_zip": null,
+          "address_zip_check": null,
+          "brand": "MasterCard",
+          "country": "US",
+          "customer": "cus_KmCAau6IU8J5l4",
+          "cvc_check": "pass",
+          "dynamic_last4": null,
+          "exp_month": 9,
+          "exp_year": 2022,
+          "fingerprint": "CIexiIsKcjMWabUj",
+          "funding": "prepaid",
+          "last4": "5100",
+          "metadata": {
+          },
+          "name": "Longbob Longsen",
+          "tokenization_method": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:51 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers/cus_KmCAau6IU8J5l4
+    body:
+      encoding: UTF-8
+      string: description=TheDesc&email=email%40example.com&expand[0]=sources
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2284'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - dd790240-e7c6-430d-a35c-e666dfc224ab
+      Original-Request:
+      - req_sdcnH11IYFtS8b
+      Request-Id:
+      - req_sdcnH11IYFtS8b
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAau6IU8J5l4",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498970,
+          "currency": null,
+          "default_source": "card_1K6dmAAWOtgoysoghviqqYnB",
+          "delinquent": false,
+          "description": "TheDesc",
+          "discount": null,
+          "email": "email@example.com",
+          "invoice_prefix": "AF25E40C",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmAAWOtgoysoghviqqYnB",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAau6IU8J5l4",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              },
+              {
+                "id": "card_1K6dmBAWOtgoysogSaH1eTeH",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "MasterCard",
+                "country": "US",
+                "customer": "cus_KmCAau6IU8J5l4",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "CIexiIsKcjMWabUj",
+                "funding": "prepaid",
+                "last4": "5100",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 2,
+            "url": "/v1/customers/cus_KmCAau6IU8J5l4/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:52 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_validate_false.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_store_with_validate_false.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: validate=false&expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:53 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1512'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 6cb69cc2-642c-46d9-b564-ef2a22b68962
+      Original-Request:
+      - req_uBjmiWN86jksjC
+      Request-Id:
+      - req_uBjmiWN86jksjC
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAdynTB7jflP",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498973,
+          "currency": null,
+          "default_source": "card_1K6dmDAWOtgoysogWDMl8bnr",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "B157F194",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmDAWOtgoysogWDMl8bnr",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAdynTB7jflP",
+                "cvc_check": "unchecked",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAdynTB7jflP/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:53 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_unstore.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_unstore.yml
@@ -1,0 +1,200 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=Active+Merchant+Unstore+Customer&expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:54 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1537'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 182a6b60-f15a-4fea-b8bf-2f898a4c4171
+      Original-Request:
+      - req_SYQGBEwcuqulUW
+      Request-Id:
+      - req_SYQGBEwcuqulUW
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCA6eBmzQ3PF6",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498974,
+          "currency": null,
+          "default_source": "card_1K6dmEAWOtgoysogsgkaSpEI",
+          "delinquent": false,
+          "description": "Active Merchant Unstore Customer",
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "D2F1E0D7",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmEAWOtgoysogsgkaSpEI",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCA6eBmzQ3PF6",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCA6eBmzQ3PF6/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:54 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/customers/cus_KmCA6eBmzQ3PF6/cards/card_1K6dmEAWOtgoysogsgkaSpEI
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '83'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_EvjNfFnROsjSX9
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dmEAWOtgoysogsgkaSpEI",
+          "object": "card",
+          "deleted": true
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:55 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_unstore_using_deprecated_api.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_unstore_using_deprecated_api.yml
@@ -1,0 +1,200 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=Active+Merchant+Unstore+Customer&expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:56 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1537'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 441dac34-d43f-48d2-ba2e-ff2b4c28b3d1
+      Original-Request:
+      - req_JojCP2dJjgj3az
+      Request-Id:
+      - req_JojCP2dJjgj3az
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAYrhX6kw9Jv",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498976,
+          "currency": null,
+          "default_source": "card_1K6dmGAWOtgoysogdnpOoik0",
+          "delinquent": false,
+          "description": "Active Merchant Unstore Customer",
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "CDDE7468",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmGAWOtgoysogdnpOoik0",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAYrhX6kw9Jv",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAYrhX6kw9Jv/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:56 GMT
+- request:
+    method: delete
+    uri: https://api.stripe.com/v1/customers/cus_KmCAYrhX6kw9Jv/cards/card_1K6dmGAWOtgoysogdnpOoik0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:57 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '83'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_ARJVkrXZDoMQBq
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dmGAWOtgoysogdnpOoik0",
+          "object": "card",
+          "deleted": true
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:57 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_update.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_update.yml
@@ -1,0 +1,229 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: description=Active+Merchant+Update+Credit+Card&expand[0]=sources&card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1539'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f91153c5-8b01-4fa1-8366-bd239d06de15
+      Original-Request:
+      - req_T1wn9ZuPeAtjmx
+      Request-Id:
+      - req_T1wn9ZuPeAtjmx
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCAiyUkG1paMG",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639498977,
+          "currency": null,
+          "default_source": "card_1K6dmIAWOtgoysogoamkIVUL",
+          "delinquent": false,
+          "description": "Active Merchant Update Credit Card",
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "A1D6F20C",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "card_1K6dmIAWOtgoysogoamkIVUL",
+                "object": "card",
+                "address_city": null,
+                "address_country": null,
+                "address_line1": null,
+                "address_line1_check": null,
+                "address_line2": null,
+                "address_state": null,
+                "address_zip": null,
+                "address_zip_check": null,
+                "brand": "Visa",
+                "country": "US",
+                "customer": "cus_KmCAiyUkG1paMG",
+                "cvc_check": "pass",
+                "dynamic_last4": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "last4": "4242",
+                "metadata": {
+                },
+                "name": "Longbob Longsen",
+                "tokenization_method": null
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCAiyUkG1paMG/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:58 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers/cus_KmCAiyUkG1paMG/cards/card_1K6dmIAWOtgoysogoamkIVUL
+    body:
+      encoding: UTF-8
+      string: name=John+Doe&address_line1=123+Main+Street&address_city=Pleasantville&address_state=NY&address_zip=12345&exp_year=2023&exp_month=6
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:22:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '617'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - bc425b28-e933-4e7e-977b-539e8f36a757
+      Original-Request:
+      - req_4BkvBjK0kViAz7
+      Request-Id:
+      - req_4BkvBjK0kViAz7
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "card_1K6dmIAWOtgoysogoamkIVUL",
+          "object": "card",
+          "address_city": "Pleasantville",
+          "address_country": null,
+          "address_line1": "123 Main Street",
+          "address_line1_check": "pass",
+          "address_line2": null,
+          "address_state": "NY",
+          "address_zip": "12345",
+          "address_zip_check": "pass",
+          "brand": "Visa",
+          "country": "US",
+          "customer": "cus_KmCAiyUkG1paMG",
+          "cvc_check": "pass",
+          "dynamic_last4": null,
+          "exp_month": 6,
+          "exp_year": 2023,
+          "fingerprint": "hfaVNMiXc0dYSiC5",
+          "funding": "credit",
+          "last4": "4242",
+          "metadata": {
+          },
+          "name": "John Doe",
+          "tokenization_method": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:22:59 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 92f9b4ed-2104-45a4-bb21-b652ecdb01a7
+      Original-Request:
+      - req_7Mx5zUcvpfW2Zo
+      Request-Id:
+      - req_7Mx5zUcvpfW2Zo
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmKAWOtgoysog3GiXHCPP",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498980,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 46,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmKAWOtgoysogzzc0IGEO",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmKAWOtgoysog3GiXHCPP/rcpt_KmCAJSBxcPus1uZz22hnBDZHatYRKOA",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmKAWOtgoysog3GiXHCPP/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmKAWOtgoysogzzc0IGEO",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:00 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmKAWOtgoysog3GiXHCPP/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:01 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 9baca74f-f059-401b-9c1a-eecd3741078f
+      Original-Request:
+      - req_H94d08PJ808ssZ
+      Request-Id:
+      - req_H94d08PJ808ssZ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmKAWOtgoysog3XFAZ3uU",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmKAWOtgoysog3GiXHCPP",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498980,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 46,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmKAWOtgoysogzzc0IGEO",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmKAWOtgoysog3GiXHCPP/rcpt_KmCAJSBxcPus1uZz22hnBDZHatYRKOA",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmKAWOtgoysog3XFAZ3uU",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmKAWOtgoysog3GiXHCPP",
+                  "created": 1639498981,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmKAWOtgoysog3GiXHCPP/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmKAWOtgoysogzzc0IGEO",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498981,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:01 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_aud.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_aud.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=aud&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 728935e3-589a-49ab-ade9-2af189cea47b
+      Original-Request:
+      - req_m6iOYfglO1n56v
+      Request-Id:
+      - req_m6iOYfglO1n56v
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmMAWOtgoysog2lrZy7cr",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498982,
+          "currency": "aud",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 42,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmMAWOtgoysogtNNvECPk",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmMAWOtgoysog2lrZy7cr/rcpt_KmCAUqyK7fXZGGDYVWSujMzX73rV9qG",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmMAWOtgoysog2lrZy7cr/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmMAWOtgoysogtNNvECPk",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:03 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmMAWOtgoysog2lrZy7cr/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:04 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 2cba5d49-7f7e-400a-888f-3d79680c2178
+      Original-Request:
+      - req_xcRWIobUFZuibc
+      Request-Id:
+      - req_xcRWIobUFZuibc
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmMAWOtgoysog29qRkZOI",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmMAWOtgoysog2lrZy7cr",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498982,
+            "currency": "aud",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 42,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmMAWOtgoysogtNNvECPk",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmMAWOtgoysog2lrZy7cr/rcpt_KmCAUqyK7fXZGGDYVWSujMzX73rV9qG",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmMAWOtgoysog29qRkZOI",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmMAWOtgoysog2lrZy7cr",
+                  "created": 1639498984,
+                  "currency": "aud",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmMAWOtgoysog2lrZy7cr/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmMAWOtgoysogtNNvECPk",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498984,
+          "currency": "aud",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:04 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_cad.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_cad.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=cad&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:06 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 874d834f-b50f-441c-9d81-63094fdec05c
+      Original-Request:
+      - req_0cz4NAHMBeXY5c
+      Request-Id:
+      - req_0cz4NAHMBeXY5c
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmPAWOtgoysog1Dqk54ID",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498985,
+          "currency": "cad",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 63,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmPAWOtgoysogAKpGYKgd",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmPAWOtgoysog1Dqk54ID/rcpt_KmCATb4ZDjqojFR02D4QUFHJGATBKeA",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmPAWOtgoysog1Dqk54ID/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmPAWOtgoysogAKpGYKgd",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:06 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmPAWOtgoysog1Dqk54ID/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:07 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - c5f10f4a-b499-4b83-9f29-a8649c11d7ea
+      Original-Request:
+      - req_vBQDPE6l1Tnxat
+      Request-Id:
+      - req_vBQDPE6l1Tnxat
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmPAWOtgoysog15bIexzL",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmPAWOtgoysog1Dqk54ID",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498985,
+            "currency": "cad",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 63,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmPAWOtgoysogAKpGYKgd",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmPAWOtgoysog1Dqk54ID/rcpt_KmCATb4ZDjqojFR02D4QUFHJGATBKeA",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmPAWOtgoysog15bIexzL",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmPAWOtgoysog1Dqk54ID",
+                  "created": 1639498987,
+                  "currency": "cad",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmPAWOtgoysog1Dqk54ID/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmPAWOtgoysogAKpGYKgd",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498987,
+          "currency": "cad",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:07 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_chf.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_chf.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=chf&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 989efa79-0226-45f6-8e74-d769538abe87
+      Original-Request:
+      - req_LFK5ru4VDZaf4p
+      Request-Id:
+      - req_LFK5ru4VDZaf4p
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmSAWOtgoysog1e5P1dDM",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498988,
+          "currency": "chf",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 52,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmRAWOtgoysogxfoZdjDn",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmSAWOtgoysog1e5P1dDM/rcpt_KmCAOb9rhm1974whU9KuUUAG2fzXpRB",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmSAWOtgoysog1e5P1dDM/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmRAWOtgoysogxfoZdjDn",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:08 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmSAWOtgoysog1e5P1dDM/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - efdad8fd-db26-4ecc-801d-31b84e8858ae
+      Original-Request:
+      - req_YjzSMfJDgRK6Ec
+      Request-Id:
+      - req_YjzSMfJDgRK6Ec
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmSAWOtgoysog1K6wVDPP",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmSAWOtgoysog1e5P1dDM",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498988,
+            "currency": "chf",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 52,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmRAWOtgoysogxfoZdjDn",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmSAWOtgoysog1e5P1dDM/rcpt_KmCAOb9rhm1974whU9KuUUAG2fzXpRB",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmSAWOtgoysog1K6wVDPP",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmSAWOtgoysog1e5P1dDM",
+                  "created": 1639498989,
+                  "currency": "chf",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmSAWOtgoysog1e5P1dDM/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmRAWOtgoysogxfoZdjDn",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498989,
+          "currency": "chf",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:09 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_dkk.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_dkk.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=500&currency=dkk&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 50711989-cf5b-4c00-b43b-6109f66dfe67
+      Original-Request:
+      - req_6VFem7i3a3FzcK
+      Request-Id:
+      - req_6VFem7i3a3FzcK
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmUAWOtgoysog3yZQ9khS",
+          "object": "charge",
+          "amount": 500,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498990,
+          "currency": "dkk",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 51,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmUAWOtgoysogLSMdK1zr",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmUAWOtgoysog3yZQ9khS/rcpt_KmCACl4Aia3c2gHnHCS5EFfqIK9xXf0",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmUAWOtgoysog3yZQ9khS/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmUAWOtgoysogLSMdK1zr",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:10 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmUAWOtgoysog3yZQ9khS/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:12 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 9e489715-e051-419f-853d-50c60639aaa3
+      Original-Request:
+      - req_AWhQTyEtsoTXkZ
+      Request-Id:
+      - req_AWhQTyEtsoTXkZ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmUAWOtgoysog3mZWmTDO",
+          "object": "refund",
+          "amount": 500,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmUAWOtgoysog3yZQ9khS",
+            "object": "charge",
+            "amount": 500,
+            "amount_captured": 0,
+            "amount_refunded": 500,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498990,
+            "currency": "dkk",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 51,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmUAWOtgoysogLSMdK1zr",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmUAWOtgoysog3yZQ9khS/rcpt_KmCACl4Aia3c2gHnHCS5EFfqIK9xXf0",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmUAWOtgoysog3mZWmTDO",
+                  "object": "refund",
+                  "amount": 500,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmUAWOtgoysog3yZQ9khS",
+                  "created": 1639498991,
+                  "currency": "dkk",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmUAWOtgoysog3yZQ9khS/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmUAWOtgoysogLSMdK1zr",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498991,
+          "currency": "dkk",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:11 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_eur.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_eur.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=eur&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3109'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 221693ea-1232-44b3-8886-57d17ae9c943
+      Original-Request:
+      - req_87utWTxmSLpHZM
+      Request-Id:
+      - req_87utWTxmSLpHZM
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmWAWOtgoysog0yJEujEJ",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498992,
+          "currency": "eur",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 8,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmWAWOtgoysogIqflXT7z",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmWAWOtgoysog0yJEujEJ/rcpt_KmCAKoZkQs8b0RCpJo5p6wCXwFmAjZB",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmWAWOtgoysog0yJEujEJ/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmWAWOtgoysogIqflXT7z",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:13 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmWAWOtgoysog0yJEujEJ/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:14 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4229'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 7d8c962a-7814-4502-9810-58e98c4c3f60
+      Original-Request:
+      - req_KFCkje5uZcSifl
+      Request-Id:
+      - req_KFCkje5uZcSifl
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmWAWOtgoysog07DPfFTR",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmWAWOtgoysog0yJEujEJ",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498992,
+            "currency": "eur",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 8,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmWAWOtgoysogIqflXT7z",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmWAWOtgoysog0yJEujEJ/rcpt_KmCAKoZkQs8b0RCpJo5p6wCXwFmAjZB",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmWAWOtgoysog07DPfFTR",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmWAWOtgoysog0yJEujEJ",
+                  "created": 1639498994,
+                  "currency": "eur",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmWAWOtgoysog0yJEujEJ/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmWAWOtgoysogIqflXT7z",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498994,
+          "currency": "eur",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:14 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_gbp.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_gbp.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=60&currency=gbp&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:16 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3109'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - e78f162b-afd5-43a3-8dab-6b18f8257cf1
+      Original-Request:
+      - req_Iz3V1er4H4OsJk
+      Request-Id:
+      - req_Iz3V1er4H4OsJk
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmZAWOtgoysog3MJidERF",
+          "object": "charge",
+          "amount": 60,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498995,
+          "currency": "gbp",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 56,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmZAWOtgoysogYk4B5Uwy",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmZAWOtgoysog3MJidERF/rcpt_KmCAo2ZVRnpJC44BLoF0LPugJ2xOaPr",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmZAWOtgoysog3MJidERF/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmZAWOtgoysogYk4B5Uwy",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:15 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmZAWOtgoysog3MJidERF/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:17 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4226'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - c8ed1c45-1d2f-4b54-ba60-1c160d1f57b2
+      Original-Request:
+      - req_A3TiDrZImuLyu1
+      Request-Id:
+      - req_A3TiDrZImuLyu1
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmZAWOtgoysog3Av4ASv9",
+          "object": "refund",
+          "amount": 60,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmZAWOtgoysog3MJidERF",
+            "object": "charge",
+            "amount": 60,
+            "amount_captured": 0,
+            "amount_refunded": 60,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498995,
+            "currency": "gbp",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 56,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmZAWOtgoysogYk4B5Uwy",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmZAWOtgoysog3MJidERF/rcpt_KmCAo2ZVRnpJC44BLoF0LPugJ2xOaPr",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmZAWOtgoysog3Av4ASv9",
+                  "object": "refund",
+                  "amount": 60,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmZAWOtgoysog3MJidERF",
+                  "created": 1639498996,
+                  "currency": "gbp",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmZAWOtgoysog3MJidERF/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmZAWOtgoysogYk4B5Uwy",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498996,
+          "currency": "gbp",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:16 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_hkd.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_hkd.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=800&currency=hkd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 45a854a8-d25f-4a4e-ae45-6d4ecfcf67ad
+      Original-Request:
+      - req_loIq7TViQHXMC5
+      Request-Id:
+      - req_loIq7TViQHXMC5
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmbAWOtgoysog3CchLTnM",
+          "object": "charge",
+          "amount": 800,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639498997,
+          "currency": "hkd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 40,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmbAWOtgoysogEmYH5TBY",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmbAWOtgoysog3CchLTnM/rcpt_KmCAt0gJWi03LTQAoipyjZUOGBVNdDV",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmbAWOtgoysog3CchLTnM/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmbAWOtgoysogEmYH5TBY",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:18 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmbAWOtgoysog3CchLTnM/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 3571149b-d69b-4bb4-836d-0dc7b3dc10de
+      Original-Request:
+      - req_qzJm1jmK0EZh99
+      Request-Id:
+      - req_qzJm1jmK0EZh99
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmbAWOtgoysog3Gh8y4F0",
+          "object": "refund",
+          "amount": 800,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmbAWOtgoysog3CchLTnM",
+            "object": "charge",
+            "amount": 800,
+            "amount_captured": 0,
+            "amount_refunded": 800,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639498997,
+            "currency": "hkd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 40,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmbAWOtgoysogEmYH5TBY",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmbAWOtgoysog3CchLTnM/rcpt_KmCAt0gJWi03LTQAoipyjZUOGBVNdDV",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmbAWOtgoysog3Gh8y4F0",
+                  "object": "refund",
+                  "amount": 800,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmbAWOtgoysog3CchLTnM",
+                  "created": 1639498999,
+                  "currency": "hkd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmbAWOtgoysog3CchLTnM/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmbAWOtgoysogEmYH5TBY",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639498999,
+          "currency": "hkd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:19 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_jpy.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_jpy.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=jpy&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4f43e86d-46a2-4664-b53b-291376c41b6a
+      Original-Request:
+      - req_aNj4Mcmwg41u6B
+      Request-Id:
+      - req_aNj4Mcmwg41u6B
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmeAWOtgoysog1Xw5vSAk",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499000,
+          "currency": "jpy",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 28,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmeAWOtgoysog810J3MQd",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmeAWOtgoysog1Xw5vSAk/rcpt_KmCBHnzOV8Dr31xap4WGK16nuRMQTvB",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmeAWOtgoysog1Xw5vSAk/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmeAWOtgoysog810J3MQd",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:20 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmeAWOtgoysog1Xw5vSAk/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 71bcdf46-c730-453f-8e80-1ea095db7357
+      Original-Request:
+      - req_sjN2lDH2nt9RzQ
+      Request-Id:
+      - req_sjN2lDH2nt9RzQ
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmeAWOtgoysog14eCWCbQ",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmeAWOtgoysog1Xw5vSAk",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499000,
+            "currency": "jpy",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 28,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmeAWOtgoysog810J3MQd",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmeAWOtgoysog1Xw5vSAk/rcpt_KmCBHnzOV8Dr31xap4WGK16nuRMQTvB",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmeAWOtgoysog14eCWCbQ",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmeAWOtgoysog1Xw5vSAk",
+                  "created": 1639499001,
+                  "currency": "jpy",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmeAWOtgoysog1Xw5vSAk/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmeAWOtgoysog810J3MQd",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499001,
+          "currency": "jpy",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:21 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_mxn.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_mxn.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=2000&currency=mxn&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:23 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3111'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ef5a969b-6df5-4cc6-8133-cee50e41e245
+      Original-Request:
+      - req_8LacHJARgDBORe
+      Request-Id:
+      - req_8LacHJARgDBORe
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmgAWOtgoysog2hThbxSD",
+          "object": "charge",
+          "amount": 2000,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499002,
+          "currency": "mxn",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmgAWOtgoysogldzXtn2i",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmgAWOtgoysog2hThbxSD/rcpt_KmCBPDm2CocBmxIvLZE5453h5MQSjVM",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmgAWOtgoysog2hThbxSD/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmgAWOtgoysogldzXtn2i",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:23 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmgAWOtgoysog2hThbxSD/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4234'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 78f20c29-9f53-4f00-9c00-76ac103e2f19
+      Original-Request:
+      - req_fWrAl1ysxbB0iL
+      Request-Id:
+      - req_fWrAl1ysxbB0iL
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmgAWOtgoysog2EJVzOn6",
+          "object": "refund",
+          "amount": 2000,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmgAWOtgoysog2hThbxSD",
+            "object": "charge",
+            "amount": 2000,
+            "amount_captured": 0,
+            "amount_refunded": 2000,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499002,
+            "currency": "mxn",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 38,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmgAWOtgoysogldzXtn2i",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmgAWOtgoysog2hThbxSD/rcpt_KmCBPDm2CocBmxIvLZE5453h5MQSjVM",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmgAWOtgoysog2EJVzOn6",
+                  "object": "refund",
+                  "amount": 2000,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmgAWOtgoysog2hThbxSD",
+                  "created": 1639499004,
+                  "currency": "mxn",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmgAWOtgoysog2hThbxSD/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmgAWOtgoysogldzXtn2i",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499004,
+          "currency": "mxn",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:24 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_nok.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_nok.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=600&currency=nok&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3109'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - d491e18e-0bc0-451d-b9d6-86567f6a2be6
+      Original-Request:
+      - req_zPgjWJljaTLyXz
+      Request-Id:
+      - req_zPgjWJljaTLyXz
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmiAWOtgoysog30dkyv4S",
+          "object": "charge",
+          "amount": 600,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499004,
+          "currency": "nok",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 3,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmiAWOtgoysogSi251G8z",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmiAWOtgoysog30dkyv4S/rcpt_KmCBwnKvicesH6YRFh4gVa3kWBpo3MI",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmiAWOtgoysog30dkyv4S/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmiAWOtgoysogSi251G8z",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:25 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmiAWOtgoysog30dkyv4S/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:26 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4229'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 2ed5187a-01d0-4a3a-9582-5475afc26ad7
+      Original-Request:
+      - req_Py9iGpjUbLWCLs
+      Request-Id:
+      - req_Py9iGpjUbLWCLs
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmiAWOtgoysog3ZEqJQXD",
+          "object": "refund",
+          "amount": 600,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmiAWOtgoysog30dkyv4S",
+            "object": "charge",
+            "amount": 600,
+            "amount_captured": 0,
+            "amount_refunded": 600,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499004,
+            "currency": "nok",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 3,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmiAWOtgoysogSi251G8z",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmiAWOtgoysog30dkyv4S/rcpt_KmCBwnKvicesH6YRFh4gVa3kWBpo3MI",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmiAWOtgoysog3ZEqJQXD",
+                  "object": "refund",
+                  "amount": 600,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmiAWOtgoysog30dkyv4S",
+                  "created": 1639499006,
+                  "currency": "nok",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmiAWOtgoysog30dkyv4S/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmiAWOtgoysogSi251G8z",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499006,
+          "currency": "nok",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:26 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_sek.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_sek.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=600&currency=sek&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:27 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 4a57b043-cead-41d9-ac60-af0f0381792c
+      Original-Request:
+      - req_Iw9ZiNoCssyYwh
+      Request-Id:
+      - req_Iw9ZiNoCssyYwh
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmlAWOtgoysog3gxqsYbw",
+          "object": "charge",
+          "amount": 600,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499007,
+          "currency": "sek",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 50,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmlAWOtgoysog83rAvKSw",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmlAWOtgoysog3gxqsYbw/rcpt_KmCBydZp9Hg8TpnbBrZ3keDgmn4K5mJ",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmlAWOtgoysog3gxqsYbw/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmlAWOtgoysog83rAvKSw",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:27 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmlAWOtgoysog3gxqsYbw/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:28 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - f0cd507b-b679-47c5-bba4-35b06299bbb3
+      Original-Request:
+      - req_uSEaH2vVEzzMKn
+      Request-Id:
+      - req_uSEaH2vVEzzMKn
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmlAWOtgoysog3bZfaPLS",
+          "object": "refund",
+          "amount": 600,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmlAWOtgoysog3gxqsYbw",
+            "object": "charge",
+            "amount": 600,
+            "amount_captured": 0,
+            "amount_refunded": 600,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499007,
+            "currency": "sek",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 50,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmlAWOtgoysog83rAvKSw",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmlAWOtgoysog3gxqsYbw/rcpt_KmCBydZp9Hg8TpnbBrZ3keDgmn4K5mJ",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmlAWOtgoysog3bZfaPLS",
+                  "object": "refund",
+                  "amount": 600,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmlAWOtgoysog3gxqsYbw",
+                  "created": 1639499008,
+                  "currency": "sek",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmlAWOtgoysog3gxqsYbw/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmlAWOtgoysog83rAvKSw",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499008,
+          "currency": "sek",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:28 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_verify_sgd.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_verify_sgd.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=sgd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - c06e468b-0c18-4d1a-acc9-80ec0162ceb8
+      Original-Request:
+      - req_W4DvBVICte5Id5
+      Request-Id:
+      - req_W4DvBVICte5Id5
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmnAWOtgoysog0Q6SVHdg",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499009,
+          "currency": "sgd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 60,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmnAWOtgoysogvJkYGTzf",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmnAWOtgoysog0Q6SVHdg/rcpt_KmCBHuRlo71SdbcqVM9rKKlareUeCER",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmnAWOtgoysog0Q6SVHdg/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmnAWOtgoysogvJkYGTzf",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:29 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmnAWOtgoysog0Q6SVHdg/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4230'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 01e0c5c3-8dcc-4a14-80ff-d71aa318c18a
+      Original-Request:
+      - req_lNmYwNstsGAKKL
+      Request-Id:
+      - req_lNmYwNstsGAKKL
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmnAWOtgoysog0JufPaZi",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmnAWOtgoysog0Q6SVHdg",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499009,
+            "currency": "sgd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 60,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmnAWOtgoysogvJkYGTzf",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmnAWOtgoysog0Q6SVHdg/rcpt_KmCBHuRlo71SdbcqVM9rKKlareUeCER",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmnAWOtgoysog0JufPaZi",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmnAWOtgoysog0Q6SVHdg",
+                  "created": 1639499010,
+                  "currency": "sgd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmnAWOtgoysog0Q6SVHdg/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmnAWOtgoysogvJkYGTzf",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499010,
+          "currency": "sgd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:30 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_void.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_void.yml
@@ -1,0 +1,425 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:32 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 041a5a19-2f79-4118-a47f-c17e10a4f984
+      Original-Request:
+      - req_4iSoATvUkHa1Gi
+      Request-Id:
+      - req_4iSoATvUkHa1Gi
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmpAWOtgoysog3LlewOdI",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dmpAWOtgoysog3fD77ObS",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639499011,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 63,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmpAWOtgoysogJ6Ft8Ff7",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmpAWOtgoysog3LlewOdI/rcpt_KmCB6Q9mmnTg20Unow3fcOD60yKYIXt",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmpAWOtgoysog3LlewOdI/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmpAWOtgoysogJ6Ft8Ff7",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:31 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmpAWOtgoysog3LlewOdI/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:33 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4309'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 01b87501-7991-499c-8b54-ce2630f43910
+      Original-Request:
+      - req_jgZ0EnaJ7cl5Fs
+      Request-Id:
+      - req_jgZ0EnaJ7cl5Fs
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmpAWOtgoysog3ddnQBiD",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": "txn_3K6dmpAWOtgoysog3ge9Eq8Q",
+          "charge": {
+            "id": "ch_3K6dmpAWOtgoysog3LlewOdI",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 100,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": "txn_3K6dmpAWOtgoysog3fD77ObS",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": true,
+            "created": 1639499011,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 63,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmpAWOtgoysogJ6Ft8Ff7",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmpAWOtgoysog3LlewOdI/rcpt_KmCB6Q9mmnTg20Unow3fcOD60yKYIXt",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmpAWOtgoysog3ddnQBiD",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": "txn_3K6dmpAWOtgoysog3ge9Eq8Q",
+                  "charge": "ch_3K6dmpAWOtgoysog3LlewOdI",
+                  "created": 1639499012,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmpAWOtgoysog3LlewOdI/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmpAWOtgoysogJ6Ft8Ff7",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499012,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:33 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_void_with_metadata.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_void_with_metadata.yml
@@ -1,0 +1,427 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:34 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 58f459a1-4aef-4a49-9d6a-b78fedda70fe
+      Original-Request:
+      - req_yq4awvk9ZtL0Xt
+      Request-Id:
+      - req_yq4awvk9ZtL0Xt
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmsAWOtgoysog1lhRUTM7",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499014,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 13,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmsAWOtgoysogradjI5o8",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmsAWOtgoysog1lhRUTM7/rcpt_KmCBXreaC1XjIJUbEgVPBf2XWqjwEXV",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmsAWOtgoysog1lhRUTM7/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmsAWOtgoysogradjI5o8",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:34 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmsAWOtgoysog1lhRUTM7/refunds
+    body:
+      encoding: UTF-8
+      string: metadata[test_metadata]=123&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:35 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4292'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 189a2a42-1471-41d0-89b8-279202809d5b
+      Original-Request:
+      - req_4he1zXbeXlW6Nd
+      Request-Id:
+      - req_4he1zXbeXlW6Nd
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmsAWOtgoysog1GlfwInj",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmsAWOtgoysog1lhRUTM7",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499014,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 13,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmsAWOtgoysogradjI5o8",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmsAWOtgoysog1lhRUTM7/rcpt_KmCBXreaC1XjIJUbEgVPBf2XWqjwEXV",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmsAWOtgoysog1GlfwInj",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmsAWOtgoysog1lhRUTM7",
+                  "created": 1639499015,
+                  "currency": "usd",
+                  "metadata": {
+                    "test_metadata": "123"
+                  },
+                  "payment_intent": null,
+                  "reason": null,
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmsAWOtgoysog1lhRUTM7/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmsAWOtgoysogradjI5o8",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499015,
+          "currency": "usd",
+          "metadata": {
+            "test_metadata": "123"
+          },
+          "payment_intent": null,
+          "reason": null,
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:35 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_successful_void_with_reason.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_successful_void_with_reason.yml
@@ -1,0 +1,426 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3110'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 1ff15b80-b230-4d0a-8ba8-1c3a65a10d6d
+      Original-Request:
+      - req_SiQ9DCyusGcn4e
+      Request-Id:
+      - req_SiQ9DCyusGcn4e
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmuAWOtgoysog2mLDpCBB",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 0,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": null,
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": false,
+          "created": 1639499016,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmuAWOtgoysogEuaBfQyE",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmuAWOtgoysog2mLDpCBB/rcpt_KmCBXS5kTn3zWNKiPVwErpVzNB7VRzc",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmuAWOtgoysog2mLDpCBB/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmuAWOtgoysogEuaBfQyE",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:36 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/ch_3K6dmuAWOtgoysog2mLDpCBB/refunds
+    body:
+      encoding: UTF-8
+      string: reason=fraudulent&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '4280'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 89eb4c79-2dbe-479c-8374-3bfa623508ca
+      Original-Request:
+      - req_9zTGbEGURJksa1
+      Request-Id:
+      - req_9zTGbEGURJksa1
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "re_3K6dmuAWOtgoysog2XkO1BD3",
+          "object": "refund",
+          "amount": 100,
+          "balance_transaction": null,
+          "charge": {
+            "id": "ch_3K6dmuAWOtgoysog2mLDpCBB",
+            "object": "charge",
+            "amount": 100,
+            "amount_captured": 0,
+            "amount_refunded": 100,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": "Longbob Longsen",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "SPREEDLY",
+            "captured": false,
+            "created": 1639499016,
+            "currency": "usd",
+            "customer": null,
+            "description": "ActiveMerchant Test Purchase",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": {
+              "user_report": "fraudulent"
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+              "email": "wow@example.com"
+            },
+            "on_behalf_of": null,
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 38,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
+            },
+            "paid": true,
+            "payment_intent": null,
+            "payment_method": "card_1K6dmuAWOtgoysogEuaBfQyE",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "ds_transaction_id": null,
+                "exp_month": 9,
+                "exp_year": 2022,
+                "fingerprint": "hfaVNMiXc0dYSiC5",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "moto": null,
+                "network": "visa",
+                "network_transaction_id": "1041029786787710",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmuAWOtgoysog2mLDpCBB/rcpt_KmCBXS5kTn3zWNKiPVwErpVzNB7VRzc",
+            "refunded": true,
+            "refunds": {
+              "object": "list",
+              "data": [
+                {
+                  "id": "re_3K6dmuAWOtgoysog2XkO1BD3",
+                  "object": "refund",
+                  "amount": 100,
+                  "balance_transaction": null,
+                  "charge": "ch_3K6dmuAWOtgoysog2mLDpCBB",
+                  "created": 1639499017,
+                  "currency": "usd",
+                  "metadata": {
+                  },
+                  "payment_intent": null,
+                  "reason": "fraudulent",
+                  "receipt_number": null,
+                  "source_transfer_reversal": null,
+                  "status": "succeeded",
+                  "transfer_reversal": null
+                }
+              ],
+              "has_more": false,
+              "total_count": 1,
+              "url": "/v1/charges/ch_3K6dmuAWOtgoysog2mLDpCBB/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": {
+              "id": "card_1K6dmuAWOtgoysogEuaBfQyE",
+              "object": "card",
+              "address_city": null,
+              "address_country": null,
+              "address_line1": null,
+              "address_line1_check": null,
+              "address_line2": null,
+              "address_state": null,
+              "address_zip": null,
+              "address_zip_check": null,
+              "brand": "Visa",
+              "country": "US",
+              "customer": null,
+              "cvc_check": "pass",
+              "dynamic_last4": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "last4": "4242",
+              "metadata": {
+              },
+              "name": "Longbob Longsen",
+              "tokenization_method": null
+            },
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "succeeded",
+            "transfer_data": null,
+            "transfer_group": null
+          },
+          "created": 1639499017,
+          "currency": "usd",
+          "metadata": {
+          },
+          "payment_intent": null,
+          "reason": "fraudulent",
+          "receipt_number": null,
+          "source_transfer_reversal": null,
+          "status": "succeeded",
+          "transfer_reversal": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:37 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_transcript_scrubbing.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_transcript_scrubbing.yml
@@ -1,0 +1,198 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:39 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '3137'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ee289573-1ca0-4071-80b5-1fe89672ed89
+      Original-Request:
+      - req_iHJ6GrUToGxBJE
+      Request-Id:
+      - req_iHJ6GrUToGxBJE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "ch_3K6dmwAWOtgoysog3OX0t6el",
+          "object": "charge",
+          "amount": 100,
+          "amount_captured": 100,
+          "amount_refunded": 0,
+          "application": null,
+          "application_fee": null,
+          "application_fee_amount": null,
+          "balance_transaction": "txn_3K6dmwAWOtgoysog3nDwk6gX",
+          "billing_details": {
+            "address": {
+              "city": null,
+              "country": null,
+              "line1": null,
+              "line2": null,
+              "postal_code": null,
+              "state": null
+            },
+            "email": null,
+            "name": "Longbob Longsen",
+            "phone": null
+          },
+          "calculated_statement_descriptor": "SPREEDLY",
+          "captured": true,
+          "created": 1639499018,
+          "currency": "usd",
+          "customer": null,
+          "description": "ActiveMerchant Test Purchase",
+          "destination": null,
+          "dispute": null,
+          "disputed": false,
+          "failure_code": null,
+          "failure_message": null,
+          "fraud_details": {
+          },
+          "invoice": null,
+          "livemode": false,
+          "metadata": {
+            "email": "wow@example.com"
+          },
+          "on_behalf_of": null,
+          "order": null,
+          "outcome": {
+            "network_status": "approved_by_network",
+            "reason": null,
+            "risk_level": "normal",
+            "risk_score": 38,
+            "seller_message": "Payment complete.",
+            "type": "authorized"
+          },
+          "paid": true,
+          "payment_intent": null,
+          "payment_method": "card_1K6dmwAWOtgoysogxVlYk5J1",
+          "payment_method_details": {
+            "card": {
+              "brand": "visa",
+              "checks": {
+                "address_line1_check": null,
+                "address_postal_code_check": null,
+                "cvc_check": "pass"
+              },
+              "country": "US",
+              "ds_transaction_id": null,
+              "exp_month": 9,
+              "exp_year": 2022,
+              "fingerprint": "hfaVNMiXc0dYSiC5",
+              "funding": "credit",
+              "installments": null,
+              "last4": "4242",
+              "mandate": null,
+              "moto": null,
+              "network": "visa",
+              "network_transaction_id": "1041029786787710",
+              "three_d_secure": null,
+              "wallet": null
+            },
+            "type": "card"
+          },
+          "receipt_email": null,
+          "receipt_number": null,
+          "receipt_url": "https://pay.stripe.com/receipts/acct_160DX6AWOtgoysog/ch_3K6dmwAWOtgoysog3OX0t6el/rcpt_KmCBCwwNSk6qko2Fov2b2lbyKcsU9Ph",
+          "refunded": false,
+          "refunds": {
+            "object": "list",
+            "data": [
+
+            ],
+            "has_more": false,
+            "total_count": 0,
+            "url": "/v1/charges/ch_3K6dmwAWOtgoysog3OX0t6el/refunds"
+          },
+          "review": null,
+          "shipping": null,
+          "source": {
+            "id": "card_1K6dmwAWOtgoysogxVlYk5J1",
+            "object": "card",
+            "address_city": null,
+            "address_country": null,
+            "address_line1": null,
+            "address_line1_check": null,
+            "address_line2": null,
+            "address_state": null,
+            "address_zip": null,
+            "address_zip_check": null,
+            "brand": "Visa",
+            "country": "US",
+            "customer": null,
+            "cvc_check": "pass",
+            "dynamic_last4": null,
+            "exp_month": 9,
+            "exp_year": 2022,
+            "fingerprint": "hfaVNMiXc0dYSiC5",
+            "funding": "credit",
+            "last4": "4242",
+            "metadata": {
+            },
+            "name": "Longbob Longsen",
+            "tokenization_method": null
+          },
+          "source_transfer": null,
+          "statement_descriptor": null,
+          "statement_descriptor_suffix": null,
+          "status": "succeeded",
+          "transfer_data": null,
+          "transfer_group": null
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:39 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_echeck_auth_with_verified_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_echeck_auth_with_verified_account.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_7s22nNueP2Hjj6&card=ba_17cHxeAWOtgoysogv3NM8CJ1&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '128'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 16886d78-09d0-4492-bc5c-717311bd0887
+      Original-Request:
+      - req_eWpbG5lPVt276Q
+      Request-Id:
+      - req_eWpbG5lPVt276Q
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "You cannot pass capture=false for this payment type.",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:40 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:41 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '269'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 242a66b3-3fbe-4b56-93c3-e06e9d777459
+      Original-Request:
+      - req_en3ZKyC9m92ZmE
+      Request-Id:
+      - req_en3ZKyC9m92ZmE
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3K6dmyAWOtgoysog029yUQ1i",
+            "code": "card_declined",
+            "decline_code": "generic_decline",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:41 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase_from_stored_but_unverified_bank_account.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase_from_stored_but_unverified_bank_account.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/tokens?bank_account%5Baccount_holder_name%5D=Jim%20Smith&bank_account%5Baccount_holder_type%5D=individual&bank_account%5Baccount_number%5D=000123456789&bank_account%5Bcountry%5D=US&bank_account%5Bcurrency%5D=usd&bank_account%5Brouting_number%5D=110000000
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '585'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - be868d59-e047-499f-a914-6e784d24b1b4
+      Original-Request:
+      - req_roQX3aUXwhYSGP
+      Request-Id:
+      - req_roQX3aUXwhYSGP
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "btok_1K6dn0AWOtgoysogBJsVCDn2",
+          "object": "token",
+          "bank_account": {
+            "id": "ba_1K6dn0AWOtgoysog0cfqUZ8s",
+            "object": "bank_account",
+            "account_holder_name": "Jim Smith",
+            "account_holder_type": "individual",
+            "account_type": null,
+            "bank_name": "STRIPE TEST BANK",
+            "country": "US",
+            "currency": "usd",
+            "fingerprint": "uCkXlMFxqys7GosR",
+            "last4": "6789",
+            "routing_number": "110000000",
+            "status": "new"
+          },
+          "client_ip": "181.51.32.190",
+          "created": 1639499022,
+          "livemode": false,
+          "type": "bank_account",
+          "used": false
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:42 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/customers
+    body:
+      encoding: UTF-8
+      string: expand[0]=sources&source=btok_1K6dn0AWOtgoysogBJsVCDn2
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1269'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 52545152-764a-430f-b68d-30b3f094169b
+      Original-Request:
+      - req_b6IJYgUbJThuVK
+      Request-Id:
+      - req_b6IJYgUbJThuVK
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "id": "cus_KmCBggUGfElJ0K",
+          "object": "customer",
+          "address": null,
+          "balance": 0,
+          "created": 1639499022,
+          "currency": null,
+          "default_source": "ba_1K6dn0AWOtgoysog0cfqUZ8s",
+          "delinquent": false,
+          "description": null,
+          "discount": null,
+          "email": null,
+          "invoice_prefix": "3BCA1852",
+          "invoice_settings": {
+            "custom_fields": null,
+            "default_payment_method": null,
+            "footer": null
+          },
+          "livemode": false,
+          "metadata": {
+          },
+          "name": null,
+          "next_invoice_sequence": 1,
+          "phone": null,
+          "preferred_locales": [
+
+          ],
+          "shipping": null,
+          "sources": {
+            "object": "list",
+            "data": [
+              {
+                "id": "ba_1K6dn0AWOtgoysog0cfqUZ8s",
+                "object": "bank_account",
+                "account_holder_name": "Jim Smith",
+                "account_holder_type": "individual",
+                "account_type": null,
+                "bank_name": "STRIPE TEST BANK",
+                "country": "US",
+                "currency": "usd",
+                "customer": "cus_KmCBggUGfElJ0K",
+                "fingerprint": "uCkXlMFxqys7GosR",
+                "last4": "6789",
+                "metadata": {
+                },
+                "routing_number": "110000000",
+                "status": "new"
+              }
+            ],
+            "has_more": false,
+            "total_count": 1,
+            "url": "/v1/customers/cus_KmCBggUGfElJ0K/sources"
+          },
+          "tax_exempt": "none"
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:43 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: customer=cus_KmCBggUGfElJ0K&card=ba_1K6dn0AWOtgoysog0cfqUZ8s&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '381'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - ab7991fc-151c-4415-bb7a-51f16294a589
+      Original-Request:
+      - req_VxxLiyqeHSnxPr
+      Request-Id:
+      - req_VxxLiyqeHSnxPr
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "bank_account_unverified",
+            "doc_url": "https://stripe.com/docs/error-codes/bank-account-unverified",
+            "message": "The customer's bank account must be verified in order to create an ACH payment. For more information, see https://stripe.com/docs/guides/ach#manually-collecting-and-verifying-bank-accounts",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:44 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase_with_destination_and_amount.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_purchase_with_destination_and_amount.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&destination[account]=acct_1K5HlrPT5iqVqrJn&destination[amount]=120
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '181'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 20cc19c9-3c54-4578-865e-6797b74767e4
+      Original-Request:
+      - req_pZ7hGdtEu26CXI
+      Request-Id:
+      - req_pZ7hGdtEu26CXI
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "`destination[amount]` must be less than or equal to the charge amount",
+            "param": "destination[amount]",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:45 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_refund.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_refund.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/active_merchant_fake_charge/refunds
+    body:
+      encoding: UTF-8
+      string: amount=100&expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '243'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - '08843a95-0137-437a-ad58-f52cde372e86'
+      Original-Request:
+      - req_DtOrTt2EiAisHK
+      Request-Id:
+      - req_DtOrTt2EiAisHK
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "resource_missing",
+            "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
+            "message": "No such charge: 'active_merchant_fake_charge'",
+            "param": "id",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:45 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_verify.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_verify.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges
+    body:
+      encoding: UTF-8
+      string: card[number]=[FILTERED]&card[exp_month]=9&card[exp_year]=2022&card[cvc]=[FILTERED]&card[name]=Longbob+Longsen&amount=100&currency=usd&description=ActiveMerchant+Test+Purchase&payment_user_agent=Stripe%2Fv1+ActiveMerchantBindings%2F1.124.0&metadata[email]=wow%40example.com&capture=false
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 402
+      message: Payment Required
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '269'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 56919345-7e9f-4d10-b2e5-95184338c918
+      Original-Request:
+      - req_CkSXSRAwiHp71p
+      Request-Id:
+      - req_CkSXSRAwiHp71p
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "charge": "ch_3K6dn4AWOtgoysog3f4pNGDv",
+            "code": "card_declined",
+            "decline_code": "generic_decline",
+            "doc_url": "https://stripe.com/docs/error-codes/card-declined",
+            "message": "Your card was declined.",
+            "type": "card_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:47 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_void.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_unsuccessful_void.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/charges/active_merchant_fake_charge/refunds
+    body:
+      encoding: UTF-8
+      string: expand[0]=charge
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '243'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Idempotency-Key:
+      - 132fe090-605f-44fa-be62-3f4dce545469
+      Original-Request:
+      - req_YYNjIF8fUoY3zv
+      Request-Id:
+      - req_YYNjIF8fUoY3zv
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "resource_missing",
+            "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
+            "message": "No such charge: 'active_merchant_fake_charge'",
+            "param": "id",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:47 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/remote_stripe_test/test_verify_credentials.yml
+++ b/test/vcr_cassettes/remote_stripe_test/test_verify_credentials.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/nonexistent
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:48 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '227'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Request-Id:
+      - req_6xqTfp37G5wRuu
+      Stripe-Version:
+      - '2020-08-27'
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "resource_missing",
+            "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
+            "message": "No such charge: 'nonexistent'",
+            "param": "id",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:48 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/charges/nonexistent
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Basic <AUTH_DATA>
+      User-Agent:
+      - Stripe/v1 ActiveMerchantBindings/1.124.0
+      Stripe-Version:
+      - '2020-08-27'
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"1.124.0","lang":"ruby","lang_version":"2.5.7 p206 (2019-10-01)","platform":"x86_64-darwin20","publisher":"active_merchant"}'
+      X-Stripe-Client-User-Metadata:
+      - '{"ip":null}'
+      Connection:
+      - close
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 14 Dec 2021 16:23:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '120'
+      Connection:
+      - close
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, HEAD, OPTIONS, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Www-Authenticate:
+      - Basic realm="Stripe"
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Invalid API Key provided: an_unkno******_key",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 14 Dec 2021 16:23:48 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## Summary:

Adds the VCR gem in order to record and stub the
remote tests interactions and configures a module
that adds the needed callbacks to record a cassette
for each test.

## Test Suite
### Unit Tests:
Finished in 16.81839 seconds.
5010 tests, 74852 assertions, 0 failures, 0 errors,
0 pendings, 0 omissions, 0 notifications
100% passed

### Remote Tests:
bundle exec ruby -Itest test/remote/gateways/remote_stripe_test.rb

Finished in 0.675177 seconds.
74 tests, 339 assertions, 0 failures, 0 errors, 0 pendings,
0 omissions, 0 notifications
100% passed

### Rubocop
726 files inspected, no offenses detected