### PR TITLE
StripePI: Set restriction for [Apple/Google] Pay

### DIFF
--- a/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
+++ b/lib/active_merchant/billing/gateways/stripe_payment_intents.rb
@@ -11,8 +11,15 @@ module ActiveMerchant #:nodoc:
       CONFIRM_INTENT_ATTRIBUTES = %i[receipt_email return_url save_payment_method setup_future_usage off_session]
       UPDATE_INTENT_ATTRIBUTES = %i[description statement_descriptor_suffix statement_descriptor receipt_email setup_future_usage]
       DEFAULT_API_VERSION = '2020-08-27'
+      NO_WALLET_SUPPORT = %w(apple_pay google_pay android_pay)
 
       def create_intent(money, payment_method, options = {})
+        @card_source_pay = payment_method.source.to_s if defined?(payment_method.source)
+        @card_brand_pay = card_brand(payment_method) unless payment_method.is_a?(String) || payment_method.nil?
+        if NO_WALLET_SUPPORT.include?(@card_source_pay) || NO_WALLET_SUPPORT.include?(@card_brand_pay)
+          store_apple_or_google_pay_token = 'Direct [Apple/Google] Pay transactions are not supported. Those payment methods must be stored before use.'
+          return Response.new(false, store_apple_or_google_pay_token)
+        end
         post = {}
         add_amount(post, money, options, true)
         add_capture_method(post, options)

--- a/test/remote/gateways/remote_stripe_payment_intents_test.rb
+++ b/test/remote/gateways/remote_stripe_payment_intents_test.rb
@@ -35,6 +35,7 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
       verification_value: '737',
       month: 10,
       year: 2028)
+    @apple_pay = apple_pay_payment_token
     @destination_account = fixtures(:stripe_destination)[:stripe_user_id]
   end
 
@@ -61,6 +62,16 @@ class RemoteStripeIntentsTest < Test::Unit::TestCase
 
     assert_equal 'succeeded', purchase.params['status']
     assert purchase.params.dig('charges', 'data')[0]['captured']
+  end
+
+  def test_unsuccessful_purchase_apple_pay
+    options = {
+      currency: 'GBP',
+      customer: @customer
+    }
+    assert error = @gateway.purchase(@amount, @apple_pay, options)
+    p error.message
+    assert_equal 'Direct [Apple/Google] Pay transactions are not supported. Those payment methods must be stored before use.', error.message
   end
 
   def test_purchases_with_same_idempotency_key

--- a/test/unit/gateways/stripe_payment_intents_test.rb
+++ b/test/unit/gateways/stripe_payment_intents_test.rb
@@ -23,6 +23,16 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
       currency: 'GBP',
       confirmation_method: 'manual'
     }
+
+    @apple_pay = apple_pay_payment_token
+    @google_pay = network_tokenization_credit_card(
+      '4777777777777778',
+      payment_cryptogram: 'BwAQCFVQdwEAABNZI1B3EGLyGC8=',
+      verification_value: '987',
+      source: :google_pay,
+      brand: 'visa',
+      eci: '5'
+    )
   end
 
   def test_successful_create_and_confirm_intent
@@ -475,6 +485,12 @@ class StripePaymentIntentsTest < Test::Unit::TestCase
   def test_supported_countries
     countries = %w(AE AT AU BE BG BR CA CH CY CZ DE DK EE ES FI FR GB GR HK HU IE IN IT JP LT LU LV MT MX MY NL NO NZ PL PT RO SE SG SI SK US)
     assert_equal countries.sort, StripePaymentIntentsGateway.supported_countries.sort
+  end
+
+  def test_unsuccessful_create_and_confirm_intent_using_apple_pay
+    assert error = @gateway.create_intent(@amount, @google_pay, @options.merge(return_url: 'https://www.example.com', capture_method: 'manual'))
+    assert_instance_of Response, error
+    assert_equal 'Direct [Apple/Google] Pay transactions are not supported. Those payment methods must be stored before use.', error.message
   end
 
   private


### PR DESCRIPTION
Sumary:
---------------------------------------
In order to prevent send direct Apple/Google Pay methods
unstored on Stripe, this PR add restriction to those methods.

Local Tests:
---------------------------------------
34 tests, 181 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Remote Tests:
---------------------------------------
67 tests, 315 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

Rubocop
---------------------------------------
725 files inspected, no offenses detected