### PR TITLE
NMI:  Update gateway credentials to use security_key

### DIFF
--- a/lib/active_merchant/billing/gateways/nmi.rb
+++ b/lib/active_merchant/billing/gateways/nmi.rb
@@ -23,7 +23,11 @@ module ActiveMerchant #:nodoc:
       end
 
       def initialize(options = {})
-        requires!(options, :login, :password)
+        if options.has_key?(:security_key)
+          requires!(options, :security_key)
+        else
+          requires!(options, :login, :password)
+        end
         super
       end
 
@@ -51,7 +55,6 @@ module ActiveMerchant #:nodoc:
         add_merchant_defined_fields(post, options)
         add_level3_fields(post, options)
         add_three_d_secure(post, options)
-
         commit('auth', post)
       end
 
@@ -127,6 +130,7 @@ module ActiveMerchant #:nodoc:
         transcript.
           gsub(%r((password=)[^&\n]*), '\1[FILTERED]').
           gsub(%r((ccnumber=)\d+), '\1[FILTERED]').
+          gsub(%r((security_key=)[^&\n]*), '\1[FILTERED]').
           gsub(%r((cvv=)\d+), '\1[FILTERED]').
           gsub(%r((checkaba=)\d+), '\1[FILTERED]').
           gsub(%r((checkaccount=)\d+), '\1[FILTERED]').
@@ -297,9 +301,9 @@ module ActiveMerchant #:nodoc:
 
       def commit(action, params)
         params[action == 'add_customer' ? :customer_vault : :type] = action
-        params[:username] = @options[:login]
-        params[:password] = @options[:password]
-
+        params[:username] = @options[:login] unless @options[:login].nil?
+        params[:password] = @options[:password] unless @options[:password].nil?
+        params[:security_key] = @options[:security_key] unless @options[:security_key].nil?
         raw_response = ssl_post(url, post_data(action, params), headers)
         response = parse(raw_response)
         succeeded = success_from(response)
@@ -325,7 +329,8 @@ module ActiveMerchant #:nodoc:
       end
 
       def headers
-        { 'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8' }
+        headers = { 'Content-Type' => 'application/x-www-form-urlencoded;charset=UTF-8' }
+        headers
       end
 
       def post_data(action, params)

--- a/test/fixtures.yml
+++ b/test/fixtures.yml
@@ -641,6 +641,9 @@ nmi:
   login: demo
   password: password
 
+nmi_secure:
+  security_key: '6457Thfj624V5r7WUwc5v6a68Zsd6YEm'
+
 ogone:
   login: LOGIN
   user: USER

--- a/test/unit/gateways/nmi_test.rb
+++ b/test/unit/gateways/nmi_test.rb
@@ -5,6 +5,7 @@ class NmiTest < Test::Unit::TestCase
 
   def setup
     @gateway = NmiGateway.new(fixtures(:nmi))
+    @gateway_secure = NmiGateway.new(fixtures(:nmi_secure))
 
     @amount = 100
     @credit_card = credit_card
@@ -28,6 +29,66 @@ class NmiTest < Test::Unit::TestCase
       descriptor_merchant_id: '120',
       descriptor_url: 'url'
     }
+  end
+
+  def test_successful_authorize_and_capture_using_security_key
+    @credit_card.number = '4111111111111111'
+    response = stub_comms do
+      @gateway_secure.authorize(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/security_key=#{@gateway_secure.options[:security_key]}/, data)
+      assert_match(/type=auth/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_authorization_response)
+    assert_success response
+    capture = stub_comms do
+      @gateway_secure.capture(@amount, response.authorization)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/security_key=#{@gateway_secure.options[:security_key]}/, data)
+      assert_match(/type=capture/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/transactionid=2762787830/, data)
+    end.respond_with(successful_capture_response)
+    assert_success capture
+  end
+
+  def test_failed_authorize_using_security_key
+    response = stub_comms do
+      @gateway_secure.authorize(@amount, @credit_card)
+    end.respond_with(failed_authorization_response)
+
+    assert_failure response
+    assert_equal 'DECLINE', response.message
+    assert response.test?
+  end
+
+  def test_successful_purchase_using_security_key
+    @credit_card.number = '4111111111111111'
+    response = stub_comms do
+      @gateway_secure.purchase(@amount, @credit_card)
+    end.check_request do |_endpoint, data, _headers|
+      assert_match(/security_key=#{@gateway_secure.options[:security_key]}/, data)
+      assert_match(/type=sale/, data)
+      assert_match(/amount=1.00/, data)
+      assert_match(/payment=creditcard/, data)
+      assert_match(/ccnumber=#{@credit_card.number}/, data)
+      assert_match(/cvv=#{@credit_card.verification_value}/, data)
+      assert_match(/ccexp=#{sprintf("%.2i", @credit_card.month)}#{@credit_card.year.to_s[-2..-1]}/, data)
+    end.respond_with(successful_purchase_response)
+    assert_success response
+    assert response.test?
+  end
+
+  def test_failed_purchase_using_security_key
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card)
+    end.respond_with(failed_purchase_response)
+    assert_failure response
+    assert response.test?
+    assert_equal 'DECLINE', response.message
   end
 
   def test_successful_purchase


### PR DESCRIPTION
Summary
-------------------------
Add security_key as a valid authentication value

Description
-------------------------
Nmi need to be able authenticate using uname/pwrod and also a security_key, because when customer
use the onboarding API they cannot generate the uname and pwrod, they generate a security_key.

they do not intend on deprecating Uname and Password any time in the future.

JIRA ticket number
-------------------------
GWI-75

Unit test
-------------------------
Finished in 9.413358 seconds.

52 tests, 394 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

5.52 tests/s, 41.86 assertions/s

Remote test
-------------------------
Finished in 120.659157 seconds.

49 tests, 178 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed

0.41 tests/s, 1.48 assertions/s

Rubocop
-------------------------
729 files inspected, no offenses detected